### PR TITLE
Optimize tensor operation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,16 +12,18 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: stable
-
-      - name: Install dependencies
+      - name: Install system dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y build-essential cmake libgmp-dev
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+          components: clippy, rustfmt
 
       - name: Cache Rust dependencies
         uses: actions/cache@v3
@@ -31,40 +33,48 @@ jobs:
             ~/.cargo/git
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
 
-      - name: Cache OpenFHE build
+      - name: Cache OpenFHE source
         uses: actions/cache@v3
         with:
-          path: openfhe/build
-          key: ${{ runner.os }}-openfhe-${{ hashFiles('openfhe/CMakeLists.txt') }}
+          path: openfhe
+          key: ${{ runner.os }}-openfhe-source-${{ hashFiles('openfhe/CMakeLists.txt') }}
           restore-keys: |
-            ${{ runner.os }}-openfhe-
+            ${{ runner.os }}-openfhe-source-
 
-      - name: Checkout OpenFHE
-        uses: actions/checkout@v2
+      - name: Checkout OpenFHE if not cached
+        if: steps.cache-openfhe-source.outputs.cache-hit != 'true'
+        uses: actions/checkout@v3
         with:
           repository: openfheorg/openfhe-development
           path: openfhe
 
-      - name: Build OpenFHE
+      - name: Cache OpenFHE build
+        id: cache-openfhe-build
+        uses: actions/cache@v3
+        with:
+          path: |
+            /usr/local/include/openfhe
+            /usr/local/lib/libOPENFHE*
+          key: ${{ runner.os }}-openfhe-build-${{ hashFiles('openfhe/CMakeLists.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-openfhe-build-
+
+      - name: Build and install OpenFHE
+        if: steps.cache-openfhe-build.outputs.cache-hit != 'true'
         run: |
           cd openfhe
           mkdir -p build && cd build
-          cmake ..
+          cmake .. -DCMAKE_BUILD_TYPE=Release
           make -j"$(nproc)"
           sudo make install
-
-      - name: Update dynamic linker cache
-        run: |
-          echo "/usr/local/lib" | sudo tee /etc/ld.so.conf.d/openfhe.conf
           sudo ldconfig
 
-      - uses: taiki-e/install-action@cargo-llvm-cov
-      - uses: taiki-e/install-action@nextest
-      - name: Install clippy and rustfmt
-        run: |
-          rustup component add clippy
-          rustup component add rustfmt
-      - uses: taiki-e/install-action@just
-      - name: Run ci
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov,nextest,just
+
+      - name: Run CI tasks
         run: just ci

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ num-traits = "0.2"
 rayon = { version = "1.5", optional = true }
 rand = { version = "0.9.0", features = ["std_rng"] }
 itertools = "0.14.0"
+memory-stats = "1.0.0"
 
 [dev-dependencies]
 keccak-asm = { version = "0.1.4" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,25 +1,33 @@
 [package]
-name = "diamond_io"
+name = "diamond-io"
 version = "0.1.0"
 edition = "2021"
 rust-version = "1.83"
 license = "MIT OR Apache-2.0"
+
+[features]
+parallel = ["rayon"]
 
 [dependencies]
 openfhe = { git = "https://github.com/MachinaIO/openfhe-rs.git", branch = "refactor2" }
 digest = "0.10"
 num-bigint = { version = "0.4", default-features = false }
 num-traits = "0.2"
-rayon = "1.5"
+rayon = { version = "1.5", optional = true }
 rand = { version = "0.9.0", features = ["std_rng"] }
 itertools = "0.14.0"
 
 [dev-dependencies]
 keccak-asm = { version = "0.1.4" }
 proptest = "1.0.0"
+criterion = "0.5.0"
 
 [profile.release]
 opt-level = 3
 lto = "thin"
 codegen-units = 1
 panic = "abort"
+
+[[bench]]
+name = "decompose_benchmark"
+harness = false

--- a/README.md
+++ b/README.md
@@ -5,5 +5,5 @@ Implementation of [Diamond iO](https://eprint.iacr.org/2025/236)
 #### Test
 
 ```
-cargo test -r
+cargo test 
 ```

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Implementation of [Diamond iO](https://eprint.iacr.org/2025/236)
 #### Test
 
 ```
-cargo test 
+cargo test  --features="parallel"
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -11,5 +11,5 @@ cargo test
 
 run io in parallel
 ```
-cargo test --package diamond-io --lib --features="parallel" -- io::test::test_io_just_mul_enc_and_bit --exact --show-output
+cargo test -r --package diamond-io --lib --features="parallel" -- io::test::test_io_just_mul_enc_and_bit --exact --show-output
 ```

--- a/README.md
+++ b/README.md
@@ -7,3 +7,9 @@ Implementation of [Diamond iO](https://eprint.iacr.org/2025/236)
 ```
 cargo test 
 ```
+
+
+run io in parallel
+```
+cargo test --package diamond-io --lib --features="parallel" -- io::test::test_io_just_mul_enc_and_bit --exact --show-output
+```

--- a/benches/decompose_benchmark.rs
+++ b/benches/decompose_benchmark.rs
@@ -1,0 +1,97 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use diamond_io::poly::{
+    dcrt::{DCRTPoly, DCRTPolyParams, FinRingElem},
+    Poly, PolyParams,
+};
+use num_bigint::BigUint;
+
+fn bench_decompose_dim_32(c: &mut Criterion) {
+    let params = DCRTPolyParams::new(32, 16, 60);
+    let q = params.modulus();
+
+    let poly1 = DCRTPoly::from_coeffs(
+        &params,
+        &vec![
+            FinRingElem::new(BigUint::from(100u32), q.clone()),
+            FinRingElem::new(BigUint::from(200u32), q.clone()),
+            FinRingElem::new(BigUint::from(300u32), q.clone()),
+            FinRingElem::new(BigUint::from(400u32), q.clone()),
+            FinRingElem::new(BigUint::from(100u32), q.clone()),
+            FinRingElem::new(BigUint::from(200u32), q.clone()),
+            FinRingElem::new(BigUint::from(300u32), q.clone()),
+            FinRingElem::new(BigUint::from(400u32), q.clone()),
+            FinRingElem::new(BigUint::from(100u32), q.clone()),
+            FinRingElem::new(BigUint::from(200u32), q.clone()),
+            FinRingElem::new(BigUint::from(300u32), q.clone()),
+            FinRingElem::new(BigUint::from(400u32), q.clone()),
+            FinRingElem::new(BigUint::from(100u32), q.clone()),
+            FinRingElem::new(BigUint::from(200u32), q.clone()),
+            FinRingElem::new(BigUint::from(300u32), q.clone()),
+            FinRingElem::new(BigUint::from(400u32), q.clone()),
+            FinRingElem::new(BigUint::from(100u32), q.clone()),
+            FinRingElem::new(BigUint::from(200u32), q.clone()),
+            FinRingElem::new(BigUint::from(300u32), q.clone()),
+            FinRingElem::new(BigUint::from(400u32), q.clone()),
+            FinRingElem::new(BigUint::from(100u32), q.clone()),
+            FinRingElem::new(BigUint::from(200u32), q.clone()),
+            FinRingElem::new(BigUint::from(300u32), q.clone()),
+            FinRingElem::new(BigUint::from(400u32), q.clone()),
+            FinRingElem::new(BigUint::from(100u32), q.clone()),
+            FinRingElem::new(BigUint::from(200u32), q.clone()),
+            FinRingElem::new(BigUint::from(300u32), q.clone()),
+            FinRingElem::new(BigUint::from(400u32), q.clone()),
+        ],
+    );
+    let poly2 = poly1.decompose(&params);
+
+    c.bench_function("DCRTPoly decompose dim 32", |b| b.iter(|| black_box(poly2.clone())));
+}
+
+fn bench_addition_dim_4(c: &mut Criterion) {
+    let params = DCRTPolyParams::new(4, 2, 60);
+    let q = params.modulus();
+
+    let poly1 = DCRTPoly::from_coeffs(
+        &params,
+        &[
+            FinRingElem::new(BigUint::from(100u32), q.clone()),
+            FinRingElem::new(BigUint::from(200u32), q.clone()),
+            FinRingElem::new(BigUint::from(300u32), q.clone()),
+            FinRingElem::new(BigUint::from(300u32), q.clone()),
+        ],
+    );
+
+    c.bench_function("DCRTPoly decompose dim 4", |b| b.iter(|| black_box(poly1.clone())));
+}
+
+fn bench_multiplication(c: &mut Criterion) {
+    let params = DCRTPolyParams::new(4, 2, 17);
+    let q = params.modulus();
+
+    let poly1 = DCRTPoly::from_coeffs(
+        &params,
+        &[
+            FinRingElem::new(BigUint::from(100u32), q.clone()),
+            FinRingElem::new(BigUint::from(200u32), q.clone()),
+        ],
+    );
+    poly1.decompose(&params);
+
+    c.bench_function("DCRTPoly multiplication", |b| b.iter(|| black_box(poly1.clone())));
+}
+
+fn bench_decomposition(c: &mut Criterion) {
+    let params = DCRTPolyParams::new(4, 2, 17);
+    let poly = DCRTPoly::const_power_of_two(&params, 5);
+
+    c.bench_function("DCRTPoly decomposition", |b| b.iter(|| black_box(poly.decompose(&params))));
+}
+
+criterion_group!(
+    benches,
+    bench_addition_dim_4,
+    bench_decompose_dim_32,
+    bench_multiplication,
+    bench_decomposition
+);
+criterion_main!(benches);

--- a/justfile
+++ b/justfile
@@ -19,7 +19,7 @@ docs:
 
 # Execute all unit tests in the workspace
 test:
-    cargo llvm-cov nextest --features="parallel"
+   cargo test --features="parallel"
 
 # Run the entire CI pipeline including format, clippy, docs, and test checks
 ci: format clippy docs test

--- a/justfile
+++ b/justfile
@@ -19,7 +19,7 @@ docs:
 
 # Execute all unit tests in the workspace
 test:
-    cargo llvm-cov nextest
+    cargo llvm-cov nextest --features="parallel"
 
 # Run the entire CI pipeline including format, clippy, docs, and test checks
 ci: format clippy docs test

--- a/src/bgg/circuit/mod.rs
+++ b/src/bgg/circuit/mod.rs
@@ -731,8 +731,8 @@ mod tests {
         let c0_eval = DCRTPoly::from_decomposed(&params, &c0_bits_eval);
         let c1_eval = DCRTPoly::from_decomposed(&params, &c1_bits_eval);
 
-        assert_eq!(c0_eval, c0.clone() * k.clone());
-        assert_eq!(c1_eval, c1.clone() * k.clone());
+        assert_eq!(c0_eval, &c0 * &k);
+        assert_eq!(c1_eval, &c1 * &k);
 
         // decrypt the result
         let plaintext = c1_eval + c0_eval * s;

--- a/src/bgg/circuit/utils.rs
+++ b/src/bgg/circuit/utils.rs
@@ -156,9 +156,9 @@ mod tests {
         let expected_out1 = pub_polys[0].clone() + pub_polys[1].clone(); // add_gate(pub_inputs[0], pub_inputs[1])
         let expected_out2 = pub_polys[1].clone() + pub_polys[2].clone(); // add_gate(pub_inputs[1], pub_inputs[2])
         let expected_out3 = pub_polys[0].clone() + pub_polys[2].clone(); // add_gate(pub_inputs[0], pub_inputs[2])
-        let expected_out4 = pub_polys[0].clone() * pub_polys[1].clone(); // mul_gate(pub_inputs[0], pub_inputs[1])
-        let expected_out5 = pub_polys[1].clone() * pub_polys[2].clone(); // mul_gate(pub_inputs[1], pub_inputs[2])
-        let expected_out6 = pub_polys[0].clone() * pub_polys[2].clone(); // mul_gate(pub_inputs[0], pub_inputs[2])
+        let expected_out4 = &pub_polys[0] * &pub_polys[1]; // mul_gate(pub_inputs[0], pub_inputs[1])
+        let expected_out5 = &pub_polys[1] * &pub_polys[2]; // mul_gate(pub_inputs[1], pub_inputs[2])
+        let expected_out6 = &pub_polys[0] * &pub_polys[2]; // mul_gate(pub_inputs[0], pub_inputs[2])
 
         assert_eq!(pub_circuit_outputs.len(), 6);
         assert_eq!(pub_circuit_outputs[0], expected_out1);
@@ -183,8 +183,8 @@ mod tests {
         let mut expected_ip2 = DCRTPoly::const_zero(&params);
 
         for i in 0..num_priv_input {
-            expected_ip1 += pub_circuit_outputs[i].clone() * priv_polys[i].clone();
-            expected_ip2 += pub_circuit_outputs[i + num_priv_input].clone() * priv_polys[i].clone();
+            expected_ip1 += &pub_circuit_outputs[i] * &priv_polys[i];
+            expected_ip2 += &pub_circuit_outputs[i + num_priv_input] * &priv_polys[i];
         }
 
         // Evaluate the inner product circuit

--- a/src/bgg/encoding.rs
+++ b/src/bgg/encoding.rs
@@ -78,14 +78,18 @@ impl<M: PolyMatrix> Mul<&Self> for BggEncoding<M> {
             panic!("Unknown plaintext for the left-hand input of multiplication");
         }
         let decomposed_b = other.pubkey.matrix.decompose();
-        let first_term = self.vector.clone() * decomposed_b;
+        let first_term = self.vector.clone() * decomposed_b.clone();
         let second_term = other.vector.clone() * self.plaintext.as_ref().unwrap();
         let new_vector = first_term + second_term;
         let new_plaintext = match (self.plaintext.as_ref(), other.plaintext.as_ref()) {
             (Some(a), Some(b)) => Some(a.clone() * b),
             _ => None,
         };
-        let new_pubkey = self.pubkey.clone() * &other.pubkey;
+
+        let new_pubkey = BggPublicKey {
+            matrix: self.pubkey.matrix.clone() * decomposed_b,
+            reveal_plaintext: self.pubkey.reveal_plaintext & other.pubkey.reveal_plaintext,
+        };
         Self { vector: new_vector, pubkey: new_pubkey, plaintext: new_plaintext }
     }
 }

--- a/src/bgg/sampler.rs
+++ b/src/bgg/sampler.rs
@@ -130,14 +130,7 @@ where
 
         let gadget = S::M::gadget_matrix(params, 2);
         let encoded_polys_vec = S::M::from_poly_vec_row(params, plaintexts.to_vec());
-        let rhs = secret_vec.clone() * gadget;
-        println!(
-            "Tensor product input sizes: encoded_polys_vec={:?}, rhs={:?}",
-            encoded_polys_vec.size(),
-            rhs.size()
-        );
-
-        let second_term = encoded_polys_vec.tensor(&rhs);
+        let second_term = encoded_polys_vec.tensor(&(secret_vec.clone() * gadget));
 
         let all_vector = first_term - second_term + error;
         parallel_iter!(plaintexts)

--- a/src/bgg/sampler.rs
+++ b/src/bgg/sampler.rs
@@ -4,7 +4,6 @@ use crate::poly::polynomial::Poly;
 use crate::poly::sampler::{DistType, PolyUniformSampler};
 use crate::poly::PolyMatrix;
 use crate::poly::{params::PolyParams, sampler::PolyHashSampler};
-use crate::utils::print_memory_usage;
 use itertools::Itertools;
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
@@ -139,10 +138,8 @@ where
         );
 
         let second_term = encoded_polys_vec.tensor(&rhs);
-        print_memory_usage("Before tensor product");
 
         let all_vector = first_term - second_term + error;
-        print_memory_usage("After tensor product");
         parallel_iter!(plaintexts)
             .enumerate()
             .map(|(idx, plaintext)| {

--- a/src/io/eval.rs
+++ b/src/io/eval.rs
@@ -6,239 +6,239 @@ use crate::poly::{matrix::*, sampler::*, Poly, PolyElem, PolyParams};
 use itertools::Itertools;
 use std::sync::Arc;
 
-pub fn eval_obf<M, SH>(
-    obf_params: ObfuscationParams<M>,
-    mut sampler_hash: SH,
-    obfuscation: Obfuscation<M>,
-    inputs: &[bool],
-) -> Vec<bool>
+impl<M> Obfuscation<M>
 where
     M: PolyMatrix,
-    SH: PolyHashSampler<[u8; 32], M = M>,
 {
-    sampler_hash.set_key(obfuscation.hash_key);
-    let params = Arc::new(obf_params.params.clone());
-    let sampler = Arc::new(sampler_hash);
-    debug_assert_eq!(inputs.len(), obf_params.input_size);
-    let bgg_pubkey_sampler = BGGPublicKeySampler::new(sampler.clone());
-    let public_data = PublicSampledData::sample(&obf_params, &bgg_pubkey_sampler);
-    let packed_output_size = public_data.packed_output_size;
-    let (mut ps, mut encodings) = (vec![], vec![]);
-    ps.push(obfuscation.p_init.clone());
-    encodings.push(obfuscation.encodings_init);
-    #[cfg(test)]
+    pub fn eval<SH>(
+        &self,
+        obf_params: ObfuscationParams<M>,
+        mut sampler_hash: SH,
+        inputs: &[bool],
+    ) -> Vec<bool>
+    where
+        SH: PolyHashSampler<[u8; 32], M = M>,
     {
-        let expected_p_init = {
-            let s_connect =
-                obfuscation.s_init.clone().concat_columns(&[obfuscation.s_init.clone()]);
-            s_connect * &obfuscation.bs[0].2
-        };
-        debug_assert_eq!(obfuscation.p_init, expected_p_init);
-
-        let zero = <M::P as Poly>::const_zero(&params);
-        let one = <M::P as Poly>::const_one(&params);
-        let enc_hardcoded_key_decomposed = obfuscation.enc_hardcoded_key.decompose().get_column(0);
-        let inserted_poly_gadget = {
-            let mut polys = vec![];
-            polys.push(one.clone());
-            for poly in enc_hardcoded_key_decomposed.iter() {
-                polys.push(poly.clone());
-            }
-            for _ in 0..(obf_params.input_size.div_ceil(params.ring_dimension() as usize)) {
-                polys.push(zero.clone());
-            }
-            polys.push(obfuscation.t_bar.entry(0, 0).clone());
-            let gadget_2 = M::gadget_matrix(&params, 2);
-            M::from_poly_vec_row(params.as_ref(), polys).tensor(&gadget_2)
-        };
-        let expected_encoding_init = obfuscation.s_init.clone()
-            * (public_data.pubkeys[0][0].concat_matrix(&public_data.pubkeys[0][1..])
-                - inserted_poly_gadget);
-        debug_assert_eq!(encodings[0][0].concat_vector(&encodings[0][1..]), expected_encoding_init);
-    }
-    // let encode_inputs =
-    //     obfuscation.encode_input.iter().map(|pubkey| pubkey.vector.clone()).collect_vec();
-    // cs_input.push(encode_inputs[0].concat_columns(&encode_inputs[1..]));
-    // let encode_fhe_key =
-    //     obfuscation.encode_fhe_key.iter().map(|pubkey| pubkey.vector.clone()).collect_vec();
-    // cs_fhe_key.push(encode_fhe_key[0].concat_columns(&encode_fhe_key[1..]));
-    let log_q = params.as_ref().modulus_bits();
-    let dim = params.as_ref().ring_dimension() as usize;
-    for (idx, input) in inputs.iter().enumerate() {
-        let m =
-            if *input { &obfuscation.m_preimages[idx].1 } else { &obfuscation.m_preimages[idx].0 };
-        let q = ps[idx].clone() * m;
-        let n =
-            if *input { &obfuscation.n_preimages[idx].1 } else { &obfuscation.n_preimages[idx].0 };
-        let p = q.clone() * n;
-        let k =
-            if *input { &obfuscation.k_preimages[idx].1 } else { &obfuscation.k_preimages[idx].0 };
-        let v = q.clone() * k;
-        // let v_input = v.slice_columns(0, 2 * log_q * (packed_input_size + 1));
-        // let v_fhe_key = v.slice_columns(
-        //     2 * log_q * (packed_input_size + 1),
-        //     2 * log_q * (packed_input_size + 3),
-        // );
-        let new_encode_vec = {
-            let t = if *input { &public_data.ts[1] } else { &public_data.ts[0] };
-            let encode_vec = encodings[idx][0].concat_vector(&encodings[idx][1..]);
-            encode_vec * t + v
-        };
-        let mut new_encodings = vec![];
-        // let zero_poly = <M::P as Poly>::const_zero(&params);
-        // let one_poly = <M::P as Poly>::const_one(&params);
-        let inserted_poly_index = 1 + log_q + idx / dim;
-        for (j, encode) in encodings[idx].iter().enumerate() {
-            // let encode = encodings[idx][j].clone();
-            let m = 2 * log_q;
-            let new_vec = new_encode_vec.slice_columns(j * m, (j + 1) * m);
-            let plaintext = if j == inserted_poly_index {
-                let inserted_coeff_index = idx % dim;
-                let mut coeffs = encode.plaintext.as_ref().unwrap().coeffs().clone();
-                coeffs[inserted_coeff_index] = if *input {
-                    <M::P as Poly>::Elem::one(&params.modulus())
-                } else {
-                    <M::P as Poly>::Elem::zero(&params.modulus())
-                };
-                Some(M::P::from_coeffs(params.as_ref(), &coeffs))
-            } else {
-                encode.plaintext.clone()
-            };
-            let new_pubkey = public_data.pubkeys[idx + 1][j].clone();
-            let new_encode: BggEncoding<M> =
-                BggEncoding::new(new_vec, new_pubkey.clone(), plaintext);
-            new_encodings.push(new_encode);
-        }
-        // let c_input = {
-        //     let t = if *input { &public_data.t_1.0 } else { &public_data.t_0.0 };
-        //     cs_input[idx].clone() * t + v_input
-        // };
-        // let c_fhe_key = {
-        //     let t = if *input { &public_data.t_1.1 } else { &public_data.t_0.1 };
-        //     cs_fhe_key[idx].clone() * t + v_fhe_key
-        // };
-        ps.push(p.clone());
-        encodings.push(new_encodings);
+        sampler_hash.set_key(self.hash_key);
+        let params = Arc::new(obf_params.params.clone());
+        let sampler = Arc::new(sampler_hash);
+        debug_assert_eq!(inputs.len(), obf_params.input_size);
+        let bgg_pubkey_sampler = BGGPublicKeySampler::new(sampler.clone());
+        let public_data = PublicSampledData::sample(&obf_params, &bgg_pubkey_sampler);
+        let packed_output_size = public_data.packed_output_size;
+        let (mut ps, mut encodings) = (vec![], vec![]);
+        ps.push(self.p_init.clone());
+        encodings.push(self.encodings_init.clone());
         #[cfg(test)]
         {
-            let mut cur_s = obfuscation.s_init.clone();
-            for bit in inputs[0..idx].iter() {
-                let r = if *bit { public_data.r_1.clone() } else { public_data.r_0.clone() };
-                cur_s = cur_s * r;
-            }
-            let new_s = if *input {
-                cur_s.clone() * public_data.r_1.clone()
-            } else {
-                cur_s.clone() * public_data.r_0.clone()
+            let expected_p_init = {
+                let s_connect = self.s_init.clone().concat_columns(&[self.s_init.clone()]);
+                s_connect * &self.bs[0].2
             };
-            let b_next_bit = if *input {
-                obfuscation.bs[idx + 1].1.clone()
-            } else {
-                obfuscation.bs[idx + 1].0.clone()
-            };
-            let expected_q = cur_s.concat_columns(&[new_s.clone()]) * &b_next_bit;
-            debug_assert_eq!(q, expected_q);
-            let expected_p = new_s.concat_columns(&[new_s.clone()]) * &obfuscation.bs[idx + 1].2;
-            debug_assert_eq!(p, expected_p);
-            let expcted_new_encode = {
-                let dim = params.ring_dimension() as usize;
-                let one = <M::P as Poly>::const_one(&params);
+            debug_assert_eq!(self.p_init, expected_p_init);
+
+            let zero = <M::P as Poly>::const_zero(&params);
+            let one = <M::P as Poly>::const_one(&params);
+            let enc_hardcoded_key_decomposed = self.enc_hardcoded_key.decompose().get_column(0);
+            let inserted_poly_gadget = {
+                let mut polys = vec![];
+                polys.push(one.clone());
+                for poly in enc_hardcoded_key_decomposed.iter() {
+                    polys.push(poly.clone());
+                }
+                for _ in 0..(obf_params.input_size.div_ceil(params.ring_dimension() as usize)) {
+                    polys.push(zero.clone());
+                }
+                polys.push(self.t_bar.entry(0, 0).clone());
                 let gadget_2 = M::gadget_matrix(&params, 2);
-                let enc_hardcoded_key_decomposed =
-                    obfuscation.enc_hardcoded_key.decompose().get_column(0);
-                let inserted_poly_gadget = {
-                    let mut polys = vec![];
-                    polys.push(one.clone());
-                    for poly in enc_hardcoded_key_decomposed.iter() {
-                        polys.push(poly.clone());
-                    }
-                    let mut coeffs = vec![];
-                    for bit in inputs[0..=idx].iter() {
-                        if *bit {
-                            coeffs.push(<M::P as Poly>::Elem::one(&params.modulus()));
-                        } else {
+                M::from_poly_vec_row(params.as_ref(), polys).tensor(&gadget_2)
+            };
+            let expected_encoding_init = self.s_init.clone()
+                * (public_data.pubkeys[0][0].concat_matrix(&public_data.pubkeys[0][1..])
+                    - inserted_poly_gadget);
+            debug_assert_eq!(
+                encodings[0][0].concat_vector(&encodings[0][1..]),
+                expected_encoding_init
+            );
+        }
+        // let encode_inputs =
+        //     self.encode_input.iter().map(|pubkey| pubkey.vector.clone()).collect_vec();
+        // cs_input.push(encode_inputs[0].concat_columns(&encode_inputs[1..]));
+        // let encode_fhe_key =
+        //     self.encode_fhe_key.iter().map(|pubkey| pubkey.vector.clone()).collect_vec();
+        // cs_fhe_key.push(encode_fhe_key[0].concat_columns(&encode_fhe_key[1..]));
+        let log_q = params.as_ref().modulus_bits();
+        let dim = params.as_ref().ring_dimension() as usize;
+        for (idx, input) in inputs.iter().enumerate() {
+            let m = if *input { &self.m_preimages[idx].1 } else { &self.m_preimages[idx].0 };
+            let q = ps[idx].clone() * m;
+            let n = if *input { &self.n_preimages[idx].1 } else { &self.n_preimages[idx].0 };
+            let p = q.clone() * n;
+            let k = if *input { &self.k_preimages[idx].1 } else { &self.k_preimages[idx].0 };
+            let v = q.clone() * k;
+            // let v_input = v.slice_columns(0, 2 * log_q * (packed_input_size + 1));
+            // let v_fhe_key = v.slice_columns(
+            //     2 * log_q * (packed_input_size + 1),
+            //     2 * log_q * (packed_input_size + 3),
+            // );
+            let new_encode_vec = {
+                let t = if *input { &public_data.ts[1] } else { &public_data.ts[0] };
+                let encode_vec = encodings[idx][0].concat_vector(&encodings[idx][1..]);
+                encode_vec * t + v
+            };
+            let mut new_encodings = vec![];
+            // let zero_poly = <M::P as Poly>::const_zero(&params);
+            // let one_poly = <M::P as Poly>::const_one(&params);
+            let inserted_poly_index = 1 + log_q + idx / dim;
+            for (j, encode) in encodings[idx].iter().enumerate() {
+                // let encode = encodings[idx][j].clone();
+                let m = 2 * log_q;
+                let new_vec = new_encode_vec.slice_columns(j * m, (j + 1) * m);
+                let plaintext = if j == inserted_poly_index {
+                    let inserted_coeff_index = idx % dim;
+                    let mut coeffs = encode.plaintext.as_ref().unwrap().coeffs().clone();
+                    coeffs[inserted_coeff_index] = if *input {
+                        <M::P as Poly>::Elem::one(&params.modulus())
+                    } else {
+                        <M::P as Poly>::Elem::zero(&params.modulus())
+                    };
+                    Some(M::P::from_coeffs(params.as_ref(), &coeffs))
+                } else {
+                    encode.plaintext.clone()
+                };
+                let new_pubkey = public_data.pubkeys[idx + 1][j].clone();
+                let new_encode: BggEncoding<M> =
+                    BggEncoding::new(new_vec, new_pubkey.clone(), plaintext);
+                new_encodings.push(new_encode);
+            }
+            // let c_input = {
+            //     let t = if *input { &public_data.t_1.0 } else { &public_data.t_0.0 };
+            //     cs_input[idx].clone() * t + v_input
+            // };
+            // let c_fhe_key = {
+            //     let t = if *input { &public_data.t_1.1 } else { &public_data.t_0.1 };
+            //     cs_fhe_key[idx].clone() * t + v_fhe_key
+            // };
+            ps.push(p.clone());
+            encodings.push(new_encodings);
+            #[cfg(test)]
+            {
+                let mut cur_s = self.s_init.clone();
+                for bit in inputs[0..idx].iter() {
+                    let r = if *bit { public_data.r_1.clone() } else { public_data.r_0.clone() };
+                    cur_s = cur_s * r;
+                }
+                let new_s = if *input {
+                    cur_s.clone() * public_data.r_1.clone()
+                } else {
+                    cur_s.clone() * public_data.r_0.clone()
+                };
+                let b_next_bit =
+                    if *input { self.bs[idx + 1].1.clone() } else { self.bs[idx + 1].0.clone() };
+                let expected_q = cur_s.concat_columns(&[new_s.clone()]) * &b_next_bit;
+                debug_assert_eq!(q, expected_q);
+                let expected_p = new_s.concat_columns(&[new_s.clone()]) * &self.bs[idx + 1].2;
+                debug_assert_eq!(p, expected_p);
+                let expcted_new_encode = {
+                    let dim = params.ring_dimension() as usize;
+                    let one = <M::P as Poly>::const_one(&params);
+                    let gadget_2 = M::gadget_matrix(&params, 2);
+                    let enc_hardcoded_key_decomposed =
+                        self.enc_hardcoded_key.decompose().get_column(0);
+                    let inserted_poly_gadget = {
+                        let mut polys = vec![];
+                        polys.push(one.clone());
+                        for poly in enc_hardcoded_key_decomposed.iter() {
+                            polys.push(poly.clone());
+                        }
+                        let mut coeffs = vec![];
+                        for bit in inputs[0..=idx].iter() {
+                            if *bit {
+                                coeffs.push(<M::P as Poly>::Elem::one(&params.modulus()));
+                            } else {
+                                coeffs.push(<M::P as Poly>::Elem::zero(&params.modulus()));
+                            }
+                        }
+                        for _ in 0..(obf_params.input_size - idx - 1) {
                             coeffs.push(<M::P as Poly>::Elem::zero(&params.modulus()));
                         }
-                    }
-                    for _ in 0..(obf_params.input_size - idx - 1) {
-                        coeffs.push(<M::P as Poly>::Elem::zero(&params.modulus()));
-                    }
-                    let input_polys = coeffs
-                        .chunks(dim)
-                        .map(|coeffs| M::P::from_coeffs(&params, coeffs))
-                        .collect_vec();
-                    polys.extend(input_polys);
-                    polys.push(obfuscation.t_bar.entry(0, 0).clone());
-                    M::from_poly_vec_row(params.as_ref(), polys).tensor(&gadget_2)
+                        let input_polys = coeffs
+                            .chunks(dim)
+                            .map(|coeffs| M::P::from_coeffs(&params, coeffs))
+                            .collect_vec();
+                        polys.extend(input_polys);
+                        polys.push(self.t_bar.entry(0, 0).clone());
+                        M::from_poly_vec_row(params.as_ref(), polys).tensor(&gadget_2)
+                    };
+                    let pubkey = public_data.pubkeys[idx + 1][0]
+                        .concat_matrix(&public_data.pubkeys[idx + 1][1..]);
+                    new_s * (pubkey - inserted_poly_gadget)
                 };
-                let pubkey = public_data.pubkeys[idx + 1][0]
-                    .concat_matrix(&public_data.pubkeys[idx + 1][1..]);
-                new_s * (pubkey - inserted_poly_gadget)
-            };
-            debug_assert_eq!(new_encode_vec, expcted_new_encode);
+                debug_assert_eq!(new_encode_vec, expcted_new_encode);
+            }
+            // cs_input.push(c_input);
+            // cs_fhe_key.push(c_fhe_key);
         }
-        // cs_input.push(c_input);
-        // cs_fhe_key.push(c_fhe_key);
-    }
-    let a_decomposed_polys = public_data.a_rlwe_bar.decompose().get_column(0);
-    let final_circuit = build_final_step_circuit::<_, BggEncoding<M>>(
-        &params,
-        &a_decomposed_polys,
-        obf_params.public_circuit.clone(),
-    );
-    let last_input_encodings = encodings.last().unwrap();
-    let output_encodings = final_circuit.eval::<BggEncoding<M>>(
-        &params,
-        last_input_encodings[0].clone(),
-        &last_input_encodings[1..],
-    );
-    let identity_2 = M::identity(&params, 2, None);
-    let unit_vector = identity_2.slice_columns(1, 2);
-    let output_encodings_vec =
-        output_encodings[0].concat_vector(&output_encodings[1..]) * unit_vector.decompose();
-    let final_v = ps.last().unwrap().clone() * &obfuscation.final_preimage;
-    let z = output_encodings_vec.clone() - final_v.clone();
-    debug_assert_eq!(z.size(), (1, packed_output_size));
-    #[cfg(test)]
-    {
-        let mut last_s = obfuscation.s_init.clone();
-        for bit in inputs.iter() {
-            let r = if *bit { public_data.r_1.clone() } else { public_data.r_0.clone() };
-            last_s = last_s * r;
-        }
-
-        let output_plaintext =
-            output_encodings[0].plaintext.as_ref().unwrap().extract_highest_bits();
-        let hardcoded_key_bits = obfuscation
-            .hardcoded_key
-            .entry(0, 0)
-            .coeffs()
-            .iter()
-            .map(|elem| elem != &<M::P as Poly>::Elem::zero(&params.modulus()))
-            .collect::<Vec<_>>();
-        debug_assert_eq!(output_plaintext, hardcoded_key_bits);
+        let a_decomposed_polys = public_data.a_rlwe_bar.decompose().get_column(0);
+        let final_circuit = build_final_step_circuit::<_, BggEncoding<M>>(
+            &params,
+            &a_decomposed_polys,
+            obf_params.public_circuit.clone(),
+        );
+        let last_input_encodings = encodings.last().unwrap();
+        let output_encodings = final_circuit.eval::<BggEncoding<M>>(
+            &params,
+            last_input_encodings[0].clone(),
+            &last_input_encodings[1..],
+        );
+        let identity_2 = M::identity(&params, 2, None);
+        let unit_vector = identity_2.slice_columns(1, 2);
+        let output_encodings_vec =
+            output_encodings[0].concat_vector(&output_encodings[1..]) * unit_vector.decompose();
+        let final_v = ps.last().unwrap().clone() * &self.final_preimage;
+        let z = output_encodings_vec.clone() - final_v.clone();
+        debug_assert_eq!(z.size(), (1, packed_output_size));
+        #[cfg(test)]
         {
-            let expcted = last_s.clone()
-                * (output_encodings[0].pubkey.matrix.clone()
-                    - M::gadget_matrix(&params, 2)
-                        * output_encodings[0].plaintext.clone().unwrap());
-            debug_assert_eq!(output_encodings[0].vector, expcted);
+            let mut last_s = self.s_init.clone();
+            for bit in inputs.iter() {
+                let r = if *bit { public_data.r_1.clone() } else { public_data.r_0.clone() };
+                last_s = last_s * r;
+            }
+
+            let output_plaintext =
+                output_encodings[0].plaintext.as_ref().unwrap().extract_highest_bits();
+            let hardcoded_key_bits = self
+                .hardcoded_key
+                .entry(0, 0)
+                .coeffs()
+                .iter()
+                .map(|elem| elem != &<M::P as Poly>::Elem::zero(&params.modulus()))
+                .collect::<Vec<_>>();
+            debug_assert_eq!(output_plaintext, hardcoded_key_bits);
+            {
+                let expcted = last_s.clone()
+                    * (output_encodings[0].pubkey.matrix.clone()
+                        - M::gadget_matrix(&params, 2)
+                            * output_encodings[0].plaintext.clone().unwrap());
+                debug_assert_eq!(output_encodings[0].vector, expcted);
+            }
+
+            // let a_f = obfuscation.final_preimage_target.slice_rows(0, 2).clone();
+            // debug_assert_eq!(output_encodings[0].pubkey.matrix.clone() * unit_vector.decompose(), a_f);
+            // let expected_final_v = last_s.clone() * &a_f;
+            // debug_assert_eq!(final_v, expected_final_v);
+
+            // let expected_output_encodings_vec = last_s.clone() * &a_f
+            //     + M::from_poly_vec_row(
+            //         &params,
+            //         vec![output_encodings[0].plaintext.as_ref().unwrap().clone()],
+            //     );
+            // debug_assert_eq!(output_encodings_vec, expected_output_encodings_vec);
+
+            // let scale = M::P::from_const(&params, &<M::P as Poly>::Elem::half_q(&params.modulus()));
+            // debug_assert_eq!(z, obfuscation.hardcoded_key * scale);
         }
-
-        // let a_f = obfuscation.final_preimage_target.slice_rows(0, 2).clone();
-        // debug_assert_eq!(output_encodings[0].pubkey.matrix.clone() * unit_vector.decompose(), a_f);
-        // let expected_final_v = last_s.clone() * &a_f;
-        // debug_assert_eq!(final_v, expected_final_v);
-
-        // let expected_output_encodings_vec = last_s.clone() * &a_f
-        //     + M::from_poly_vec_row(
-        //         &params,
-        //         vec![output_encodings[0].plaintext.as_ref().unwrap().clone()],
-        //     );
-        // debug_assert_eq!(output_encodings_vec, expected_output_encodings_vec);
-
-        // let scale = M::P::from_const(&params, &<M::P as Poly>::Elem::half_q(&params.modulus()));
-        // debug_assert_eq!(z, obfuscation.hardcoded_key * scale);
+        z.get_row(0).into_iter().flat_map(|p| p.extract_highest_bits()).collect_vec()
     }
-    z.get_row(0).into_iter().flat_map(|p| p.extract_highest_bits()).collect_vec()
 }

--- a/src/io/eval.rs
+++ b/src/io/eval.rs
@@ -3,6 +3,7 @@ use super::{Obfuscation, ObfuscationParams};
 use crate::bgg::sampler::BGGPublicKeySampler;
 use crate::bgg::BggEncoding;
 use crate::poly::{matrix::*, sampler::*, Poly, PolyElem, PolyParams};
+use crate::utils::print_memory_usage;
 use itertools::Itertools;
 use std::sync::Arc;
 
@@ -51,8 +52,17 @@ where
                 }
                 polys.push(self.t_bar.entry(0, 0).clone());
                 let gadget_2 = M::gadget_matrix(&params, 2);
-                M::from_poly_vec_row(params.as_ref(), polys).tensor(&gadget_2)
+                let mat = M::from_poly_vec_row(params.as_ref(), polys);
+                println!(
+                    "Tensor product input sizes: mat={:?}, gadget_2={:?}",
+                    mat.size(),
+                    gadget_2.size()
+                );
+                print_memory_usage("Before tensor product");
+
+                mat.tensor(&gadget_2)
             };
+            print_memory_usage("After tensor product");
             let expected_encoding_init = self.s_init.clone()
                 * (public_data.pubkeys[0][0].concat_matrix(&public_data.pubkeys[0][1..])
                     - inserted_poly_gadget);
@@ -168,8 +178,17 @@ where
                             .collect_vec();
                         polys.extend(input_polys);
                         polys.push(self.t_bar.entry(0, 0).clone());
-                        M::from_poly_vec_row(params.as_ref(), polys).tensor(&gadget_2)
+                        let mat = M::from_poly_vec_row(params.as_ref(), polys);
+                        println!(
+                            "Tensor product input sizes: mat={:?}, gadget_2={:?}",
+                            mat.size(),
+                            gadget_2.size()
+                        );
+                        print_memory_usage("Before tensor product");
+
+                        mat.tensor(&gadget_2)
                     };
+                    print_memory_usage("After tensor product");
                     let pubkey = public_data.pubkeys[idx + 1][0]
                         .concat_matrix(&public_data.pubkeys[idx + 1][1..]);
                     new_s * (pubkey - inserted_poly_gadget)

--- a/src/io/eval.rs
+++ b/src/io/eval.rs
@@ -51,8 +51,7 @@ where
                 }
                 polys.push(self.t_bar.entry(0, 0).clone());
                 let gadget_2 = M::gadget_matrix(&params, 2);
-                let mat = M::from_poly_vec_row(params.as_ref(), polys);
-                mat.tensor(&gadget_2)
+                M::from_poly_vec_row(params.as_ref(), polys).tensor(&gadget_2)
             };
             let expected_encoding_init = self.s_init.clone()
                 * (public_data.pubkeys[0][0].concat_matrix(&public_data.pubkeys[0][1..])
@@ -174,13 +173,7 @@ where
                             .collect_vec();
                         polys.extend(input_polys);
                         polys.push(self.t_bar.entry(0, 0).clone());
-                        let mat = M::from_poly_vec_row(params.as_ref(), polys);
-                        println!(
-                            "Tensor product input sizes: mat={:?}, gadget_2={:?}",
-                            mat.size(),
-                            gadget_2.size()
-                        );
-                        mat.tensor(&gadget_2)
+                        M::from_poly_vec_row(params.as_ref(), polys).tensor(&gadget_2)
                     };
                     let pubkey = public_data.pubkeys[idx + 1][0]
                         .concat_matrix(&public_data.pubkeys[idx + 1][1..]);

--- a/src/io/eval.rs
+++ b/src/io/eval.rs
@@ -92,9 +92,14 @@ where
             //     2 * log_q * (packed_input_size + 3),
             // );
             let new_encode_vec = {
-                let t = if *input { &public_data.ts[1] } else { &public_data.ts[0] };
+                let t = if *input {
+                    &public_data.rgs_decomposed[1]
+                } else {
+                    &public_data.rgs_decomposed[0]
+                };
                 let encode_vec = encodings[idx][0].concat_vector(&encodings[idx][1..]);
-                encode_vec * t + v
+                let packed_input_size = log_q + obf_params.input_size.div_ceil(dim) + 1;
+                encode_vec.mul_tensor_identity(t, packed_input_size + 1) + v
             };
             let mut new_encodings = vec![];
             // let zero_poly = <M::P as Poly>::const_zero(&params);

--- a/src/io/eval.rs
+++ b/src/io/eval.rs
@@ -3,7 +3,6 @@ use super::{Obfuscation, ObfuscationParams};
 use crate::bgg::sampler::BGGPublicKeySampler;
 use crate::bgg::BggEncoding;
 use crate::poly::{matrix::*, sampler::*, Poly, PolyElem, PolyParams};
-use crate::utils::print_memory_usage;
 use itertools::Itertools;
 use std::sync::Arc;
 
@@ -53,16 +52,8 @@ where
                 polys.push(self.t_bar.entry(0, 0).clone());
                 let gadget_2 = M::gadget_matrix(&params, 2);
                 let mat = M::from_poly_vec_row(params.as_ref(), polys);
-                println!(
-                    "Tensor product input sizes: mat={:?}, gadget_2={:?}",
-                    mat.size(),
-                    gadget_2.size()
-                );
-                print_memory_usage("Before tensor product");
-
                 mat.tensor(&gadget_2)
             };
-            print_memory_usage("After tensor product");
             let expected_encoding_init = self.s_init.clone()
                 * (public_data.pubkeys[0][0].concat_matrix(&public_data.pubkeys[0][1..])
                     - inserted_poly_gadget);
@@ -189,11 +180,8 @@ where
                             mat.size(),
                             gadget_2.size()
                         );
-                        print_memory_usage("Before tensor product");
-
                         mat.tensor(&gadget_2)
                     };
-                    print_memory_usage("After tensor product");
                     let pubkey = public_data.pubkeys[idx + 1][0]
                         .concat_matrix(&public_data.pubkeys[idx + 1][1..]);
                     new_s * (pubkey - inserted_poly_gadget)

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -4,7 +4,7 @@ pub mod utils;
 
 use crate::bgg::circuit::PolyCircuit;
 use crate::bgg::BggEncoding;
-use crate::poly::{matrix::*, polynomial::*, PolyParams};
+use crate::poly::{Poly, PolyMatrix, PolyParams};
 
 #[derive(Debug, Clone)]
 pub struct Obfuscation<M: PolyMatrix> {
@@ -40,23 +40,25 @@ pub struct ObfuscationParams<M: PolyMatrix> {
 
 #[cfg(test)]
 mod test {
-    use std::sync::Arc;
-
+    use super::*;
+    use crate::{
+        bgg::circuit::PolyCircuit,
+        io::{obf::obfuscate, ObfuscationParams},
+        poly::{
+            dcrt::{
+                DCRTPolyHashSampler, DCRTPolyMatrix, DCRTPolyParams, DCRTPolyTrapdoorSampler,
+                DCRTPolyUniformSampler,
+            },
+            PolyParams,
+        },
+    };
     use keccak_asm::Keccak256;
     use num_bigint::BigUint;
-
-    use crate::poly::{
-        dcrt::{
-            DCRTPolyHashSampler, DCRTPolyMatrix, DCRTPolyParams, DCRTPolyTrapdoorSampler,
-            DCRTPolyUniformSampler,
-        },
-        PolyParams,
-    };
-
-    use super::{eval::eval_obf, obf::obfuscate, *};
+    use std::sync::Arc;
 
     #[test]
     fn test_io_just_mul_enc_and_bit() {
+        let start_time = std::time::Instant::now();
         let params = DCRTPolyParams::default();
         let log_q = params.modulus_bits();
         let switched_modulus = Arc::new(BigUint::from(1u32));
@@ -91,7 +93,8 @@ mod test {
             sampler_trapdoor,
             &mut rng,
         );
-        println!("obfuscated");
+        let obfuscation_time = start_time.elapsed();
+        println!("Time to obfuscate: {:?}", obfuscation_time);
         let input = [true];
         let sampler_hash = DCRTPolyHashSampler::<Keccak256>::new([0; 32]);
         let hardcoded_key = obfuscation
@@ -101,8 +104,11 @@ mod test {
             .iter()
             .map(|elem| elem.value() != &BigUint::from(0u8))
             .collect::<Vec<_>>();
-        let output = eval_obf(obf_params, sampler_hash, obfuscation, &input);
+        let output = obfuscation.eval(obf_params, sampler_hash, &input);
+        let total_time = start_time.elapsed();
         println!("{:?}", output);
+        println!("Time for evaluation: {:?}", total_time - obfuscation_time);
+        println!("Total time: {:?}", total_time);
         assert_eq!(output, hardcoded_key);
     }
 }

--- a/src/io/obf.rs
+++ b/src/io/obf.rs
@@ -1,9 +1,18 @@
 use super::utils::*;
+use super::{utils::*, Obfuscation, ObfuscationParams};
 use super::{Obfuscation, ObfuscationParams};
 use crate::bgg::sampler::{BGGEncodingSampler, BGGPublicKeySampler};
 use crate::bgg::BggPublicKey;
 use crate::poly::{matrix::*, sampler::*, Poly, PolyElem, PolyParams};
 use crate::utils::print_memory_usage;
+use crate::{
+    bgg::{
+        sampler::{BGGEncodingSampler, BGGPublicKeySampler},
+        BggPublicKey,
+    },
+    join,
+    poly::{matrix::*, sampler::*, Poly, PolyElem, PolyParams},
+};
 use rand::{Rng, RngCore};
 use std::sync::Arc;
 
@@ -18,7 +27,7 @@ where
     M: PolyMatrix,
     SU: PolyUniformSampler<M = M>,
     SH: PolyHashSampler<[u8; 32], M = M>,
-    ST: PolyTrapdoorSampler<M = M>,
+    ST: PolyTrapdoorSampler<M = M> + Send + Sync,
     R: RngCore,
 {
     print_memory_usage("Obfuscation start");
@@ -85,7 +94,8 @@ where
     let encodings_init = bgg_encode_sampler.sample(&params, &public_data.pubkeys[0], &plaintexts);
     print_memory_usage("After encodings_init generation");
     // let encode_fhe_key =
-    //     bgg_encode_sampler.sample(&params, &public_data.pubkeys_fhe_key[0], &t.get_row(0), false);
+    //     bgg_encode_sampler.sample(&params, &public_data.pubkeys_fhe_key[0], &t.get_row(0),
+    // false);
 
     let mut bs = vec![];
     let mut b_trapdoors = vec![];
@@ -124,29 +134,25 @@ where
         let (b_next_0, b_next_1, b_next_star) = &bs[idx + 1];
         let (_, _, b_cur_star_trapdoor) = &b_trapdoors[idx];
         let (b_next_0_trapdoor, b_next_1_trapdoor, _) = &b_trapdoors[idx + 1];
-        let m_0 = {
-            let ub = u_0.clone() * b_next_0;
-            sampler_trapdoor.preimage(params.as_ref(), b_cur_star_trapdoor, b_cur_star, &ub)
-        };
-        let m_1 = {
-            let ub = u_1.clone() * b_next_1;
-            sampler_trapdoor.preimage(params.as_ref(), b_cur_star_trapdoor, b_cur_star, &ub)
-        };
-        m_preimages.push((m_0, m_1));
+
+        let m_preimage =
+            |a| sampler_trapdoor.preimage(params.as_ref(), b_cur_star_trapdoor, b_cur_star, &a);
+        let mp =
+            || join!(|| m_preimage(u_0.clone() * b_next_0), || m_preimage(u_1.clone() * b_next_1));
 
         let ub_star = u_star.clone() * b_next_star;
-        let n_0 = sampler_trapdoor.preimage(&params, b_next_0_trapdoor, b_next_0, &ub_star);
-        let n_1 = sampler_trapdoor.preimage(&params, b_next_1_trapdoor, b_next_1, &ub_star);
-        n_preimages.push((n_0, n_1));
-
-        let mut ks = vec![];
-        for bit in 0..2 {
+        let n_preimage = |t, n| sampler_trapdoor.preimage(&params, t, n, &ub_star);
+        let np = || {
+            join!(|| n_preimage(b_next_0_trapdoor, b_next_0), || n_preimage(
+                b_next_1_trapdoor,
+                b_next_1
+            ))
+        };
+        let k_preimage = |bit: usize| {
             let rg_decomposed = &public_data.rgs_decomposed[bit];
-            // println!("t size: {:?}", t.size());
-            let lhs = -public_data.pubkeys[idx][0].concat_matrix(&public_data.pubkeys[idx][1..]);
-            println!("lhs size: {:?}", lhs.size());
-            let top = lhs.mul_tensor_identity(rg_decomposed, 1 + packed_input_size);
-            println!("top size: {:?}", top.size());
+            let top = -public_data.pubkeys[idx][0]
+                .concat_matrix(&public_data.pubkeys[idx][1..])
+                .mul_tensor_identity(rg_decomposed, 1 + packed_input_size);
             let inserted_poly_index = 1 + log_q + idx / dim;
             let inserted_coeff_index = idx % dim;
             let zero_coeff = <M::P as Poly>::Elem::zero(&params.modulus());
@@ -185,47 +191,54 @@ where
             let k_target = top.concat_rows(&[bottom]);
             let b_matrix = if bit == 0 { b_next_0 } else { b_next_1 };
             let trapdoor = if bit == 0 { b_next_0_trapdoor } else { b_next_1_trapdoor };
-            let k = sampler_trapdoor.preimage(&params, trapdoor, b_matrix, &k_target);
-            ks.push(k);
+            sampler_trapdoor.preimage(&params, trapdoor, b_matrix, &k_target)
 
-            // let (t_input, t_fhe_key) = if bit == 0 { &public_data.t_0 } else { &public_data.t_1 };
-            // let at_input = public_data.pubkeys_input[idx][0]
-            //     .concat_matrix(&public_data.pubkeys_input[idx][1..])
-            //     * t_input;
-            // let at_fhe_key = public_data.pubkeys_fhe_key[idx][0]
-            //     .concat_matrix(&public_data.pubkeys_fhe_key[idx][1..])
-            //     * t_fhe_key;
-            // let former = at_input.concat_columns(&[at_fhe_key]);
-            // let inserted_poly_index = 1 + log_q + idx / dim;
-            // let inserted_coeff_index = idx % dim;
-            // let zero_coeff = <M::P as Poly>::Elem::zero(&params.modulus());
-            // let mut coeffs = vec![zero_coeff; dim];
-            // coeffs[inserted_coeff_index] = <M::P as Poly>::Elem::one(&params.modulus());
-            // let inserted_poly = M::P::from_coeffs(params.as_ref(), &coeffs);
-            // let inserted_poly_gadget = {
-            //     let zero = <M::P as Poly>::const_zero(params.as_ref());
-            //     let mut polys = vec![];
-            //     for _ in 0..(inserted_poly_index) {
-            //         polys.push(zero.clone());
-            //     }
-            //     polys.push(inserted_poly);
-            //     for _ in inserted_poly_index + 1..packed_input_size {
-            //         polys.push(zero.clone());
-            //     }
-            //     M::from_poly_vec_row(params.as_ref(), polys) * &gadget_2
-            // };
-            // let a_input_next = public_data.pubkeys_input[idx + 1][0]
-            //     .concat_matrix(&public_data.pubkeys_input[idx + 1][1..])
-            //     - &inserted_poly_gadget;
-            // let latter = a_input_next.concat_columns(&[public_data.pubkeys_fhe_key[idx + 1][0]
-            //     .concat_matrix(&public_data.pubkeys_fhe_key[idx + 1][1..])]);
-            // let k_target = former.concat_rows(&[latter]);
-            // let b_matrix = if bit == 0 { b_next_0 } else { b_next_1 };
-            // let trapdoor = if bit == 0 { b_next_0_trapdoor } else { b_next_1_trapdoor };
-            // let k = sampler.preimage(&params, trapdoor, b_matrix, &k_target);
-            // ks.push(k);
-        }
-        k_preimages.push((ks[0].clone(), ks[1].clone()));
+            /*
+            let (t_input, t_fhe_key) = if bit == 0 { &public_data.t_0 } else { &public_data.t_1 };
+            let at_input = public_data.pubkeys_input[idx][0]
+                .concat_matrix(&public_data.pubkeys_input[idx][1..])
+                * t_input;
+            let at_fhe_key = public_data.pubkeys_fhe_key[idx][0]
+                .concat_matrix(&public_data.pubkeys_fhe_key[idx][1..])
+                * t_fhe_key;
+            let former = at_input.concat_columns(&[at_fhe_key]);
+            let inserted_poly_index = 1 + log_q + idx / dim;
+            let inserted_coeff_index = idx % dim;
+            let zero_coeff = <M::P as Poly>::Elem::zero(&params.modulus());
+            let mut coeffs = vec![zero_coeff; dim];
+            coeffs[inserted_coeff_index] = <M::P as Poly>::Elem::one(&params.modulus());
+            let inserted_poly = M::P::from_coeffs(params.as_ref(), &coeffs);
+            let inserted_poly_gadget = {
+                let zero = <M::P as Poly>::const_zero(params.as_ref());
+                let mut polys = vec![];
+                for _ in 0..(inserted_poly_index) {
+                    polys.push(zero.clone());
+                }
+                polys.push(inserted_poly);
+                for _ in inserted_poly_index + 1..packed_input_size {
+                    polys.push(zero.clone());
+                }
+                M::from_poly_vec_row(params.as_ref(), polys) * &gadget_2
+            };
+            let a_input_next = public_data.pubkeys_input[idx + 1][0]
+                .concat_matrix(&public_data.pubkeys_input[idx + 1][1..])
+                - &inserted_poly_gadget;
+            let latter = a_input_next.concat_columns(&[public_data.pubkeys_fhe_key[idx + 1][0]
+                .concat_matrix(&public_data.pubkeys_fhe_key[idx + 1][1..])]);
+            let k_target = former.concat_rows(&[latter]);
+            let b_matrix = if bit == 0 { b_next_0 } else { b_next_1 };
+            let trapdoor = if bit == 0 { b_next_0_trapdoor } else { b_next_1_trapdoor };
+            let k = sampler.preimage(&params, trapdoor, b_matrix, &k_target);
+            ks.push(k);
+            */
+        };
+        let kp = || join!(|| k_preimage(0), || k_preimage(1));
+
+        let (mp, (np, kp)) = join!(mp, || join!(np, kp));
+
+        m_preimages.push(mp);
+        n_preimages.push(np);
+        k_preimages.push(kp);
     }
 
     let a_decomposed_polys = public_data.a_rlwe_bar.decompose().get_column(0);

--- a/src/io/obf.rs
+++ b/src/io/obf.rs
@@ -141,11 +141,11 @@ where
 
         let mut ks = vec![];
         for bit in 0..2 {
-            let t = &public_data.ts[bit];
-            println!("t size: {:?}", t.size());
+            let rg_decomposed = &public_data.rgs_decomposed[bit];
+            // println!("t size: {:?}", t.size());
             let lhs = -public_data.pubkeys[idx][0].concat_matrix(&public_data.pubkeys[idx][1..]);
             println!("lhs size: {:?}", lhs.size());
-            let top = lhs * t;
+            let top = lhs.mul_tensor_identity(rg_decomposed, 1 + packed_input_size);
             println!("top size: {:?}", top.size());
             let inserted_poly_index = 1 + log_q + idx / dim;
             let inserted_coeff_index = idx % dim;

--- a/src/io/obf.rs
+++ b/src/io/obf.rs
@@ -30,12 +30,10 @@ where
     let sampler_uniform = Arc::new(sampler_uniform);
     let sampler_hash = Arc::new(sampler_hash);
     let sampler_trapdoor = Arc::new(sampler_trapdoor);
-    // let packed_input_size = obf_params.input_size.div_ceil(dim);
     let bgg_pubkey_sampler = BGGPublicKeySampler::new(sampler_hash.clone());
     let public_data = PublicSampledData::sample(&obf_params, &bgg_pubkey_sampler);
     let packed_input_size = public_data.packed_input_size;
     let packed_output_size = public_data.packed_output_size;
-
     let s_bar =
         sampler_uniform.sample_uniform(&params, 1, 1, DistType::BitDist).entry(0, 0).clone();
     let bgg_encode_sampler = BGGEncodingSampler::new(

--- a/src/io/obf.rs
+++ b/src/io/obf.rs
@@ -158,8 +158,7 @@ where
                 for _ in (inserted_poly_index + 1)..(packed_input_size + 1) {
                     polys.push(zero.clone());
                 }
-                let mat = M::from_poly_vec_row(params.as_ref(), polys);
-                mat.tensor(&gadget_2)
+                M::from_poly_vec_row(params.as_ref(), polys).tensor(&gadget_2)
             };
 
             let bottom = public_data.pubkeys[idx + 1][0]

--- a/src/io/obf.rs
+++ b/src/io/obf.rs
@@ -3,6 +3,7 @@ use super::{Obfuscation, ObfuscationParams};
 use crate::bgg::sampler::{BGGEncodingSampler, BGGPublicKeySampler};
 use crate::bgg::BggPublicKey;
 use crate::poly::{matrix::*, sampler::*, Poly, PolyElem, PolyParams};
+use crate::utils::print_memory_usage;
 use rand::{Rng, RngCore};
 use std::sync::Arc;
 
@@ -20,6 +21,7 @@ where
     ST: PolyTrapdoorSampler<M = M>,
     R: RngCore,
 {
+    print_memory_usage("Obfuscation start");
     let public_circuit = &obf_params.public_circuit;
     let params = Arc::new(obf_params.params.clone());
     let dim = params.as_ref().ring_dimension() as usize;
@@ -31,7 +33,9 @@ where
     let sampler_hash = Arc::new(sampler_hash);
     let sampler_trapdoor = Arc::new(sampler_trapdoor);
     let bgg_pubkey_sampler = BGGPublicKeySampler::new(sampler_hash.clone());
+    print_memory_usage("Before PublicSampledData::sample");
     let public_data = PublicSampledData::sample(&obf_params, &bgg_pubkey_sampler);
+    print_memory_usage("After PublicSampledData::sample");
     let packed_input_size = public_data.packed_input_size;
     let packed_output_size = public_data.packed_output_size;
     let s_bar =
@@ -48,7 +52,10 @@ where
     //     M::from_poly_vec_row(params.as_ref(), vec![M::P::const_minus_one(params.as_ref())]);
     // let t = t_bar.concat_columns(&[minus_one_poly]);
 
+    print_memory_usage("Before hardcoded_key generation");
     let hardcoded_key = sampler_uniform.sample_uniform(&params, 1, 1, DistType::BitDist);
+    print_memory_usage("After hardcoded_key generation");
+    print_memory_usage("Before enc_hardcoded_key generation");
     let enc_hardcoded_key = {
         let e = sampler_uniform.sample_uniform(
             &params,
@@ -59,7 +66,9 @@ where
         let scale = M::P::from_const(&params, &<M::P as Poly>::Elem::half_q(&params.modulus()));
         t_bar.clone() * &public_data.a_rlwe_bar.clone() + &e - &(hardcoded_key.clone() * &scale)
     };
+    print_memory_usage("After enc_hardcoded_key generation");
     let enc_hardcoded_key_polys = enc_hardcoded_key.decompose().get_column(0);
+    print_memory_usage("After enc_hardcoded_key_polys decomposition");
 
     let mut plaintexts = vec![];
     plaintexts.extend(enc_hardcoded_key_polys);
@@ -72,7 +81,9 @@ where
     //     vec![<M::P as Poly>::const_one(params.as_ref())];
     // input_encoded_polys.extend(enc_hardcoded_key_polys);
     // input_encoded_polys.extend(zero_plaintexts);
+    print_memory_usage("Before encodings_init generation");
     let encodings_init = bgg_encode_sampler.sample(&params, &public_data.pubkeys[0], &plaintexts);
+    print_memory_usage("After encodings_init generation");
     // let encode_fhe_key =
     //     bgg_encode_sampler.sample(&params, &public_data.pubkeys_fhe_key[0], &t.get_row(0), false);
 
@@ -131,8 +142,11 @@ where
         let mut ks = vec![];
         for bit in 0..2 {
             let t = &public_data.ts[bit];
-            let top =
-                -public_data.pubkeys[idx][0].concat_matrix(&public_data.pubkeys[idx][1..]) * t;
+            println!("t size: {:?}", t.size());
+            let lhs = -public_data.pubkeys[idx][0].concat_matrix(&public_data.pubkeys[idx][1..]);
+            println!("lhs size: {:?}", lhs.size());
+            let top = lhs * t;
+            println!("top size: {:?}", top.size());
             let inserted_poly_index = 1 + log_q + idx / dim;
             let inserted_coeff_index = idx % dim;
             let zero_coeff = <M::P as Poly>::Elem::zero(&params.modulus());
@@ -153,8 +167,18 @@ where
                 for _ in (inserted_poly_index + 1)..(packed_input_size + 1) {
                     polys.push(zero.clone());
                 }
-                M::from_poly_vec_row(params.as_ref(), polys).tensor(&gadget_2)
+                let mat = M::from_poly_vec_row(params.as_ref(), polys);
+                println!(
+                    "Tensor product input sizes: mat={:?}, gadget_2={:?}",
+                    mat.size(),
+                    gadget_2.size()
+                );
+                print_memory_usage("Before tensor product");
+
+                mat.tensor(&gadget_2)
             };
+            print_memory_usage("After tensor product");
+
             let bottom = public_data.pubkeys[idx + 1][0]
                 .concat_matrix(&public_data.pubkeys[idx + 1][1..])
                 - &inserted_poly_gadget;

--- a/src/io/utils.rs
+++ b/src/io/utils.rs
@@ -2,7 +2,6 @@ use super::ObfuscationParams;
 use crate::bgg::circuit::{build_circuit_ip_to_int, PolyCircuit};
 use crate::bgg::{sampler::*, BggPublicKey, Evaluable};
 use crate::poly::{matrix::*, sampler::*, Poly, PolyParams};
-use crate::utils::print_memory_usage;
 use itertools::Itertools;
 use std::marker::PhantomData;
 
@@ -32,7 +31,6 @@ impl<S: PolyHashSampler<[u8; 32]>> PublicSampledData<S> {
         obf_params: &ObfuscationParams<S::M>,
         bgg_pubkey_sampler: &BGGPublicKeySampler<[u8; 32], S>,
     ) -> Self {
-        print_memory_usage("PublicSampledData::sample start");
         let hash_sampler = &bgg_pubkey_sampler.sampler;
         let params = &obf_params.params;
         let r_0_bar = hash_sampler.sample_hash(params, TAG_R_0, 1, 1, DistType::BitDist);
@@ -83,9 +81,7 @@ impl<S: PolyHashSampler<[u8; 32]>> PublicSampledData<S> {
                 identity_input.size(),
                 rg_decomposed.size()
             );
-            // print_memory_usage("Before tensor product");
             // let t = identity_input.clone().tensor(&rg_decomposed);
-            print_memory_usage("Removed tensor product");
             // let t_fhe_key = identity_2.clone().tensor(&rg_decomposed);
             rgs_decomposed.push(rg_decomposed);
         }

--- a/src/io/utils.rs
+++ b/src/io/utils.rs
@@ -9,7 +9,7 @@ const TAG_R_0: &[u8] = b"R_0";
 const TAG_R_1: &[u8] = b"R_1";
 const TAG_A_RLWE_BAR: &[u8] = b"A_RLWE_BAR";
 const TAG_BGG_PUBKEY_INPUT_PREFIX: &[u8] = b"BGG_PUBKEY_INPUT:";
-const TAG_BGG_PUBKEY_FHEKEY_PREFIX: &[u8] = b"BGG_PUBKEY_FHEKY:";
+const _TAG_BGG_PUBKEY_FHEKEY_PREFIX: &[u8] = b"BGG_PUBKEY_FHEKY:";
 const TAG_A_PRF: &[u8] = b"A_PRF:";
 
 #[derive(Debug, Clone)]

--- a/src/io/utils.rs
+++ b/src/io/utils.rs
@@ -2,6 +2,7 @@ use super::ObfuscationParams;
 use crate::bgg::circuit::{build_circuit_ip_to_int, PolyCircuit};
 use crate::bgg::{sampler::*, BggPublicKey, Evaluable};
 use crate::poly::{matrix::*, sampler::*, Poly, PolyParams};
+use crate::utils::print_memory_usage;
 use itertools::Itertools;
 use std::marker::PhantomData;
 
@@ -31,6 +32,7 @@ impl<S: PolyHashSampler<[u8; 32]>> PublicSampledData<S> {
         obf_params: &ObfuscationParams<S::M>,
         bgg_pubkey_sampler: &BGGPublicKeySampler<[u8; 32], S>,
     ) -> Self {
+        print_memory_usage("PublicSampledData::sample start");
         let hash_sampler = &bgg_pubkey_sampler.sampler;
         let params = &obf_params.params;
         let r_0_bar = hash_sampler.sample_hash(params, TAG_R_0, 1, 1, DistType::BitDist);
@@ -76,7 +78,14 @@ impl<S: PolyHashSampler<[u8; 32]>> PublicSampledData<S> {
             let r = if bit == 0 { r_0.clone() } else { r_1.clone() };
             let rg = r * &gadget_2;
             let rg_decomposed = rg.decompose();
+            println!(
+                "Tensor product input sizes: identity_input={:?}, rg_decomposed={:?}",
+                identity_input.size(),
+                rg_decomposed.size()
+            );
+            print_memory_usage("Before tensor product");
             let t = identity_input.clone().tensor(&rg_decomposed);
+            print_memory_usage("After tensor product");
             // let t_fhe_key = identity_2.clone().tensor(&rg_decomposed);
             ts.push(t);
         }

--- a/src/io/utils.rs
+++ b/src/io/utils.rs
@@ -68,7 +68,6 @@ impl<S: PolyHashSampler<[u8; 32]>> PublicSampledData<S> {
         //         )
         //     })
         //     .collect_vec();
-        let identity_input = S::M::identity(params, 1 + packed_input_size, None);
         let gadget_2 = S::M::gadget_matrix(params, 2);
         // let identity_2 = S::M::identity(params, 2, None);
         let mut rgs_decomposed = vec![];
@@ -76,11 +75,6 @@ impl<S: PolyHashSampler<[u8; 32]>> PublicSampledData<S> {
             let r = if bit == 0 { r_0.clone() } else { r_1.clone() };
             let rg = r * &gadget_2;
             let rg_decomposed = rg.decompose();
-            println!(
-                "Tensor product input sizes: identity_input={:?}, rg_decomposed={:?}",
-                identity_input.size(),
-                rg_decomposed.size()
-            );
             // let t = identity_input.clone().tensor(&rg_decomposed);
             // let t_fhe_key = identity_2.clone().tensor(&rg_decomposed);
             rgs_decomposed.push(rg_decomposed);

--- a/src/io/utils.rs
+++ b/src/io/utils.rs
@@ -20,7 +20,7 @@ pub struct PublicSampledData<S: PolyHashSampler<[u8; 32]>> {
     pub a_rlwe_bar: S::M,
     pub pubkeys: Vec<Vec<BggPublicKey<S::M>>>,
     // pub pubkeys_fhe_key: Vec<Vec<BggPublicKey<S::M>>>,
-    pub ts: [S::M; 2],
+    pub rgs_decomposed: [S::M; 2],
     pub a_prf: S::M,
     pub packed_input_size: usize,
     pub packed_output_size: usize,
@@ -73,7 +73,7 @@ impl<S: PolyHashSampler<[u8; 32]>> PublicSampledData<S> {
         let identity_input = S::M::identity(params, 1 + packed_input_size, None);
         let gadget_2 = S::M::gadget_matrix(params, 2);
         // let identity_2 = S::M::identity(params, 2, None);
-        let mut ts = vec![];
+        let mut rgs_decomposed = vec![];
         for bit in 0..2 {
             let r = if bit == 0 { r_0.clone() } else { r_1.clone() };
             let rg = r * &gadget_2;
@@ -83,13 +83,13 @@ impl<S: PolyHashSampler<[u8; 32]>> PublicSampledData<S> {
                 identity_input.size(),
                 rg_decomposed.size()
             );
-            print_memory_usage("Before tensor product");
-            let t = identity_input.clone().tensor(&rg_decomposed);
-            print_memory_usage("After tensor product");
+            // print_memory_usage("Before tensor product");
+            // let t = identity_input.clone().tensor(&rg_decomposed);
+            print_memory_usage("Removed tensor product");
             // let t_fhe_key = identity_2.clone().tensor(&rg_decomposed);
-            ts.push(t);
+            rgs_decomposed.push(rg_decomposed);
         }
-        let ts = ts.try_into().unwrap();
+        let rgs_decomposed = rgs_decomposed.try_into().unwrap();
         let a_prf_raw = hash_sampler.sample_hash(
             params,
             TAG_A_PRF,
@@ -103,7 +103,7 @@ impl<S: PolyHashSampler<[u8; 32]>> PublicSampledData<S> {
             r_1,
             a_rlwe_bar,
             pubkeys,
-            ts,
+            rgs_decomposed,
             a_prf,
             packed_input_size,
             packed_output_size,

--- a/src/poly/dcrt/element.rs
+++ b/src/poly/dcrt/element.rs
@@ -26,9 +26,9 @@ impl FinRingElem {
         Self { value: reduced_value, modulus }
     }
 
-    pub fn from_str<S: Into<String>>(value: S, modulus: S) -> Result<Self, ParseBigIntError> {
-        let value = BigInt::from_str(&value.into())?;
-        let modulus = BigUint::from_str(&modulus.into())?.into();
+    pub fn from_str(value: &str, modulus: &str) -> Result<Self, ParseBigIntError> {
+        let value = BigInt::from_str(value)?;
+        let modulus = BigUint::from_str(modulus)?.into();
         Ok(Self::new(value, modulus))
     }
 

--- a/src/poly/dcrt/matrix.rs
+++ b/src/poly/dcrt/matrix.rs
@@ -327,6 +327,18 @@ impl PolyMatrix for DCRTPolyMatrix {
         }
         Self { inner: new_inner, params: self.params.clone(), nrow: self.nrow, ncol: self.ncol }
     }
+
+    fn mul_tensor_identity(&self, other: &Self, identity_size: usize) -> Self {
+        assert_eq!(self.ncol, other.nrow * identity_size);
+        let slice_width = other.nrow;
+        let mut slice_results = Vec::with_capacity(identity_size);
+        for i in 0..identity_size {
+            let slice = self.slice(0, self.nrow, i * slice_width, (i + 1) * slice_width);
+            let slice_result = &slice * other;
+            slice_results.push(slice_result);
+        }
+        slice_results[0].clone().concat_columns(&slice_results[1..])
+    }
 }
 
 // ====== Arithmetic ======
@@ -500,7 +512,10 @@ mod tests {
     use num_bigint::BigUint;
 
     use super::*;
-    use crate::poly::dcrt::DCRTPolyParams;
+    use crate::poly::{
+        dcrt::{DCRTPolyParams, DCRTPolyUniformSampler},
+        sampler::PolyUniformSampler,
+    };
 
     #[test]
     fn test_gadget_matrix() {
@@ -678,5 +693,34 @@ mod tests {
         let matrix1 = DCRTPolyMatrix::zero(&params, 2, 2);
         let matrix2 = DCRTPolyMatrix::zero(&params, 3, 2);
         let _prod = matrix1 * matrix2;
+    }
+
+    #[test]
+    fn test_mul_tensor_identity() {
+        let params = DCRTPolyParams::default();
+        let sampler = DCRTPolyUniformSampler::new();
+
+        // Create matrix S (2x12)
+        let s = sampler.sample_uniform(&params, 2, 12, crate::poly::sampler::DistType::FinRingDist);
+
+        // Create 'other' matrix (3x3)
+        let other =
+            sampler.sample_uniform(&params, 3, 3, crate::poly::sampler::DistType::FinRingDist);
+
+        // Perform S * (other ⊗ I_4)
+        let result = s.mul_tensor_identity(&other, 4);
+
+        // Check dimensions
+        assert_eq!(result.row_size(), 2);
+        assert_eq!(result.col_size(), 12);
+
+        let identity = DCRTPolyMatrix::identity(&params, 4, None);
+
+        // Check result
+        let expected_result = s * (identity.tensor(&other));
+
+        assert_eq!(expected_result.row_size(), 2);
+        assert_eq!(expected_result.col_size(), 12);
+        assert_eq!(result, expected_result)
     }
 }

--- a/src/poly/dcrt/matrix.rs
+++ b/src/poly/dcrt/matrix.rs
@@ -582,7 +582,6 @@ mod tests {
     #[test]
     fn test_modulus_switch() {
         let params = DCRTPolyParams::default();
-        let modulus = params.modulus();
 
         let value00 = FinRingElem::new(1023782870921908217643761278891282178u128, params.modulus());
         let value01 = FinRingElem::new(8179012198875468938912873783289218738u128, params.modulus());

--- a/src/poly/dcrt/matrix.rs
+++ b/src/poly/dcrt/matrix.rs
@@ -52,13 +52,15 @@ impl PolyMatrix for DCRTPolyMatrix {
     type P = DCRTPoly;
 
     fn from_poly_vec(params: &DCRTPolyParams, vec: Vec<Vec<DCRTPoly>>) -> Self {
-        let mut c = vec![vec![DCRTPoly::const_zero(params); vec[0].len()]; vec.len()];
-        for (i, row) in vec.iter().enumerate() {
-            for (j, element) in row.iter().enumerate() {
-                c[i][j] = element.clone();
+        let nrow = vec.len();
+        let ncol = vec[0].len();
+        let mut c: Vec<Vec<DCRTPoly>> = vec![vec![]; nrow];
+        for (i, row) in vec.into_iter().enumerate() {
+            for element in row.into_iter() {
+                c[i].push(element);
             }
         }
-        DCRTPolyMatrix { inner: c, params: params.clone(), nrow: vec.len(), ncol: vec[0].len() }
+        DCRTPolyMatrix { inner: c, params: params.clone(), nrow, ncol }
     }
 
     fn entry(&self, i: usize, j: usize) -> &Self::P {
@@ -96,29 +98,30 @@ impl PolyMatrix for DCRTPolyMatrix {
         column_start: usize,
         column_end: usize,
     ) -> Self {
-        let mut c = vec![
-            vec![DCRTPoly::const_zero(&self.params); column_end - column_start];
-            row_end - row_start
-        ];
+        let nrow = row_end - row_start;
+        let ncol = column_end - column_start;
+
+        let mut c = Vec::with_capacity(nrow);
         for i in row_start..row_end {
+            let mut row = Vec::with_capacity(ncol);
             for j in column_start..column_end {
-                c[i - row_start][j - column_start] = self.inner[i][j].clone();
+                row.push(self.inner[i][j].clone());
             }
+            c.push(row);
         }
-        DCRTPolyMatrix {
-            inner: c,
-            params: self.params.clone(),
-            nrow: row_end - row_start,
-            ncol: column_end - column_start,
-        }
+
+        DCRTPolyMatrix { inner: c, params: self.params.clone(), nrow, ncol }
     }
 
     fn zero(params: &DCRTPolyParams, nrow: usize, ncol: usize) -> Self {
-        let mut c = vec![vec![DCRTPoly::const_zero(params); ncol]; nrow];
-        for i in 0..nrow {
-            for j in 0..ncol {
-                c[i][j] = DCRTPoly::const_zero(params).clone();
+        let mut c = Vec::with_capacity(nrow);
+        let zero_elem = DCRTPoly::const_zero(params);
+        for _ in 0..nrow {
+            let mut row = Vec::with_capacity(ncol);
+            for _ in 0..ncol {
+                row.push(zero_elem.clone());
             }
+            c.push(row);
         }
         DCRTPolyMatrix { inner: c, params: params.clone(), nrow, ncol }
     }
@@ -126,27 +129,39 @@ impl PolyMatrix for DCRTPolyMatrix {
     fn identity(params: &<Self::P as Poly>::Params, size: usize, scalar: Option<Self::P>) -> Self {
         let nrow = size;
         let ncol = size;
-        let mut result = vec![vec![DCRTPoly::const_zero(params); ncol]; nrow];
         let scalar = scalar.unwrap_or_else(|| DCRTPoly::const_one(params));
-        for i in 0..size {
-            result[i][i] = scalar.clone();
+        let zero_elem = DCRTPoly::const_zero(params);
+        let mut result = Vec::with_capacity(nrow);
+
+        for i in 0..nrow {
+            let mut row = Vec::with_capacity(ncol);
+            for j in 0..ncol {
+                if i == j {
+                    row.push(scalar.clone());
+                } else {
+                    row.push(zero_elem.clone());
+                }
+            }
+            result.push(row);
         }
+
         DCRTPolyMatrix { inner: result, params: params.clone(), nrow, ncol }
     }
 
     fn transpose(&self) -> Self {
         let nrow = self.ncol;
         let ncol = self.nrow;
-        let mut result: Vec<Vec<DCRTPoly>> =
-            vec![vec![DCRTPoly::const_zero(&self.params); ncol]; nrow];
+        let mut result = Vec::with_capacity(nrow);
         for i in 0..nrow {
+            let mut row = Vec::with_capacity(ncol);
             for j in 0..ncol {
-                result[i][j] = self.inner[j][i].clone();
+                row.push(self.inner[j][i].clone());
             }
+            result.push(row);
         }
+
         DCRTPolyMatrix { inner: result, params: self.params.clone(), nrow, ncol }
     }
-
     // (m * n1), (m * n2) -> (m * (n1 + n2))
     fn concat_columns(&self, others: &[Self]) -> Self {
         #[cfg(debug_assertions)]
@@ -156,25 +171,18 @@ impl PolyMatrix for DCRTPolyMatrix {
             }
         }
         let ncol = self.ncol + others.iter().map(|x| x.ncol).sum::<usize>();
-        let mut result: Vec<Vec<DCRTPoly>> =
-            vec![vec![DCRTPoly::const_zero(&self.params); ncol]; self.nrow];
-
-        // Copy elements from self
+        let mut result = Vec::with_capacity(self.nrow);
         for i in 0..self.nrow {
+            let mut row = Vec::with_capacity(ncol);
             for j in 0..self.ncol {
-                result[i][j] = self.inner[i][j].clone();
+                row.push(self.inner[i][j].clone());
             }
-        }
-
-        // Copy elements from others
-        let mut offset = self.ncol;
-        for other in others {
-            for i in 0..self.nrow {
+            for other in others {
                 for j in 0..other.ncol {
-                    result[i][offset + j] = other.inner[i][j].clone();
+                    row.push(other.inner[i][j].clone());
                 }
             }
-            offset += other.ncol;
+            result.push(row);
         }
 
         DCRTPolyMatrix { inner: result, params: self.params.clone(), nrow: self.nrow, ncol }
@@ -189,25 +197,22 @@ impl PolyMatrix for DCRTPolyMatrix {
             }
         }
         let nrow = self.nrow + others.iter().map(|x| x.nrow).sum::<usize>();
-        let mut result: Vec<Vec<DCRTPoly>> =
-            vec![vec![DCRTPoly::const_zero(&self.params); self.ncol]; nrow];
-
-        // Copy elements from self
+        let mut result = Vec::with_capacity(nrow);
         for i in 0..self.nrow {
+            let mut row = Vec::with_capacity(self.ncol);
             for j in 0..self.ncol {
-                result[i][j] = self.inner[i][j].clone();
+                row.push(self.inner[i][j].clone());
             }
+            result.push(row);
         }
-
-        // Copy elements from others
-        let mut offset = self.nrow;
         for other in others {
             for i in 0..other.nrow {
+                let mut row = Vec::with_capacity(self.ncol);
                 for j in 0..other.ncol {
-                    result[offset + i][j] = other.inner[i][j].clone();
+                    row.push(other.inner[i][j].clone());
                 }
+                result.push(row);
             }
-            offset += other.nrow;
         }
 
         DCRTPolyMatrix { inner: result, params: self.params.clone(), nrow, ncol: self.ncol }
@@ -217,26 +222,35 @@ impl PolyMatrix for DCRTPolyMatrix {
     fn concat_diag(&self, others: &[Self]) -> Self {
         let nrow = self.nrow + others.iter().map(|x| x.nrow).sum::<usize>();
         let ncol = self.ncol + others.iter().map(|x| x.ncol).sum::<usize>();
-        let mut result: Vec<Vec<DCRTPoly>> =
-            vec![vec![DCRTPoly::const_zero(&self.params); ncol]; nrow];
-
-        // Copy elements from self
+        let mut result = Vec::with_capacity(nrow);
+        let zero_elem = DCRTPoly::const_zero(&self.params);
         for i in 0..self.nrow {
+            let mut row = Vec::with_capacity(ncol);
             for j in 0..self.ncol {
-                result[i][j] = self.inner[i][j].clone();
+                row.push(self.inner[i][j].clone());
             }
+            for _ in self.ncol..ncol {
+                row.push(zero_elem.clone());
+            }
+
+            result.push(row);
         }
 
-        // Copy elements from others
-        let mut row_offset = self.nrow;
         let mut col_offset = self.ncol;
         for other in others {
             for i in 0..other.nrow {
-                for j in 0..other.ncol {
-                    result[row_offset + i][col_offset + j] = other.inner[i][j].clone();
+                let mut row = Vec::with_capacity(ncol);
+                for _ in 0..col_offset {
+                    row.push(zero_elem.clone());
                 }
+                for j in 0..other.ncol {
+                    row.push(other.inner[i][j].clone());
+                }
+                for _ in (col_offset + other.ncol)..ncol {
+                    row.push(zero_elem.clone());
+                }
+                result.push(row);
             }
-            row_offset += other.nrow;
             col_offset += other.ncol;
         }
 
@@ -246,18 +260,16 @@ impl PolyMatrix for DCRTPolyMatrix {
     fn tensor(&self, other: &Self) -> Self {
         let nrow = self.nrow * other.nrow;
         let ncol = self.ncol * other.ncol;
-        let mut result: Vec<Vec<DCRTPoly>> =
-            vec![vec![DCRTPoly::const_zero(&self.params); ncol]; nrow];
-
+        let mut result: Vec<Vec<DCRTPoly>> = Vec::with_capacity(nrow);
         for i1 in 0..self.nrow {
-            for j1 in 0..self.ncol {
-                for i2 in 0..other.nrow {
+            for i2 in 0..other.nrow {
+                let mut row = Vec::with_capacity(ncol);
+                for j1 in 0..self.ncol {
                     for j2 in 0..other.ncol {
-                        let i = i1 * other.nrow + i2;
-                        let j = j1 * other.ncol + j2;
-                        result[i][j] = self.inner[i1][j1].clone() * other.inner[i2][j2].clone();
+                        row.push(self.inner[i1][j1].clone() * other.inner[i2][j2].clone());
                     }
                 }
+                result.push(row);
             }
         }
 
@@ -279,16 +291,21 @@ impl PolyMatrix for DCRTPolyMatrix {
     fn decompose(&self) -> Self {
         let bit_length = self.params.modulus_bits();
         let new_nrow = self.nrow * bit_length;
-        let mut new_inner = vec![vec![DCRTPoly::const_zero(&self.params); self.ncol]; new_nrow];
-
+        let mut new_inner = Vec::with_capacity(new_nrow);
         for i in 0..self.nrow {
+            let mut decomposed_rows =
+                (0..bit_length).map(|_| Vec::with_capacity(self.ncol)).collect::<Vec<_>>();
             for j in 0..self.ncol {
                 let decomposed = self.inner[i][j].decompose(&self.params);
                 for bit in 0..bit_length {
-                    new_inner[i * bit_length + bit][j] = decomposed[bit].clone();
+                    decomposed_rows[bit].push(decomposed[bit].clone());
                 }
             }
+            for row in decomposed_rows {
+                new_inner.push(row);
+            }
         }
+
         Self { nrow: new_nrow, ncol: self.ncol, inner: new_inner, params: self.params.clone() }
     }
 
@@ -347,13 +364,15 @@ impl Neg for DCRTPolyMatrix {
     type Output = Self;
 
     fn neg(self) -> Self::Output {
-        let mut c: Vec<Vec<DCRTPoly>> =
-            vec![vec![DCRTPoly::const_zero(&self.params); self.ncol]; self.nrow];
+        let mut c = Vec::with_capacity(self.nrow);
         for i in 0..self.nrow {
+            let mut row = Vec::with_capacity(self.ncol);
             for j in 0..self.ncol {
-                c[i][j] = -self.inner[i][j].clone();
+                row.push(-self.inner[i][j].clone());
             }
+            c.push(row);
         }
+
         DCRTPolyMatrix { inner: c, params: self.params, nrow: self.nrow, ncol: self.ncol }
     }
 }
@@ -381,14 +400,19 @@ impl<'a> Mul<&'a DCRTPolyMatrix> for DCRTPolyMatrix {
             );
         }
         let common = self.ncol;
-        let mut c: Vec<Vec<DCRTPoly>> = vec![vec![DCRTPoly::const_zero(&self.params); ncol]; nrow];
+        let mut c = Vec::with_capacity(nrow);
         for i in 0..nrow {
+            let mut row = Vec::with_capacity(ncol);
             for j in 0..ncol {
-                for k in 0..common {
-                    c[i][j] += self.inner[i][k].clone() * rhs.inner[k][j].clone();
+                let mut sum = self.inner[i][0].clone() * rhs.inner[0][j].clone();
+                for k in 1..common {
+                    sum += self.inner[i][k].clone() * rhs.inner[k][j].clone();
                 }
+                row.push(sum);
             }
+            c.push(row);
         }
+
         DCRTPolyMatrix { inner: c, params: self.params, nrow, ncol }
     }
 }

--- a/src/poly/dcrt/matrix.rs
+++ b/src/poly/dcrt/matrix.rs
@@ -707,7 +707,7 @@ mod tests {
         let other =
             sampler.sample_uniform(&params, 3, 3, crate::poly::sampler::DistType::FinRingDist);
 
-        // Perform S * (other ⊗ I_4)
+        // Perform S * (I_4 ⊗ other)
         let result = s.mul_tensor_identity(&other, 4);
 
         // Check dimensions

--- a/src/poly/dcrt/params.rs
+++ b/src/poly/dcrt/params.rs
@@ -1,7 +1,7 @@
 use crate::poly::params::PolyParams;
 use num_bigint::BigUint;
 use num_traits::Num;
-use openfhe::ffi::{self};
+use openfhe::ffi;
 use std::{fmt::Debug, sync::Arc};
 
 #[derive(Clone)]
@@ -53,7 +53,7 @@ impl Default for DCRTPolyParams {
 impl DCRTPolyParams {
     pub fn new(ring_dimension: u32, crt_depth: usize, crt_bits: usize) -> Self {
         // assert that ring_dimension is a power of 2
-        assert!(ring_dimension.is_power_of_two(), "n must be a power of 2");
+        assert!(ring_dimension.is_power_of_two(), "ring_dimension must be a power of 2");
         let modulus = ffi::GenModulus(ring_dimension, crt_depth, crt_bits);
         Self {
             ring_dimension,

--- a/src/poly/dcrt/poly.rs
+++ b/src/poly/dcrt/poly.rs
@@ -104,7 +104,7 @@ impl Poly for DCRTPoly {
             let power_of_two = BigUint::from(2u32).pow(i as u32);
             let const_poly_power_of_two =
                 Self::from_const(params, &FinRingElem::new(power_of_two, params.modulus()));
-            reconstructed += bit_poly.clone() * const_poly_power_of_two;
+            reconstructed += bit_poly * &const_poly_power_of_two;
         }
         reconstructed
     }
@@ -179,6 +179,14 @@ impl<'a> Mul<&'a DCRTPoly> for DCRTPoly {
     type Output = Self;
 
     fn mul(self, rhs: &'a Self) -> Self::Output {
+        &self * rhs
+    }
+}
+
+impl<'a> Mul<&'a DCRTPoly> for &'a DCRTPoly {
+    type Output = DCRTPoly;
+
+    fn mul(self, rhs: Self) -> Self::Output {
         DCRTPoly::new(ffi::DCRTPolyMul(&rhs.ptr_poly, &self.ptr_poly))
     }
 }
@@ -310,7 +318,7 @@ mod tests {
         let sum = poly1.clone() + poly2.clone();
 
         // 5. Test multiplication.
-        let product = poly1.clone() * poly2.clone();
+        let product = &poly1 * &poly2;
 
         // 6. Test negation / subtraction.
         let neg_poly2 = poly2.clone().neg();

--- a/src/poly/dcrt/poly.rs
+++ b/src/poly/dcrt/poly.rs
@@ -82,13 +82,9 @@ impl Poly for DCRTPoly {
 
     fn from_coeffs(params: &Self::Params, coeffs: &[Self::Elem]) -> Self {
         let mut coeffs_cxx = Vec::with_capacity(coeffs.len());
-        let modulus = params.modulus();
         for coeff in coeffs {
             #[cfg(debug_assertions)]
-            {
-                let coeff_modulus = coeff.modulus();
-                assert_eq!(coeff_modulus, modulus.as_ref());
-            }
+            assert_eq!(coeff.modulus(), params.modulus().as_ref());
             coeffs_cxx.push(coeff.value().to_string());
         }
         Self::poly_gen_from_vec(params, coeffs_cxx)

--- a/src/poly/dcrt/poly.rs
+++ b/src/poly/dcrt/poly.rs
@@ -135,7 +135,7 @@ impl Poly for DCRTPoly {
     fn decompose(&self, params: &Self::Params) -> Vec<Self> {
         let coeffs = self.coeffs();
         let bit_length = params.modulus_bits();
-        (0..bit_length)
+        parallel_iter!(0..bit_length)
             .map(|h| {
                 let bit_coeffs: Vec<_> = coeffs
                     .iter()

--- a/src/poly/dcrt/poly.rs
+++ b/src/poly/dcrt/poly.rs
@@ -23,6 +23,7 @@ pub struct DCRTPoly {
     ptr_poly: Arc<UniquePtr<DCRTPolyCxx>>,
 }
 
+// SAFETY: DCRTPoly is plain old data and is shared across threads in C++ OpenFHE as well.
 unsafe impl Send for DCRTPoly {}
 unsafe impl Sync for DCRTPoly {}
 
@@ -83,8 +84,7 @@ impl Poly for DCRTPoly {
     fn from_coeffs(params: &Self::Params, coeffs: &[Self::Elem]) -> Self {
         let mut coeffs_cxx = Vec::with_capacity(coeffs.len());
         for coeff in coeffs {
-            #[cfg(debug_assertions)]
-            assert_eq!(coeff.modulus(), params.modulus().as_ref());
+            debug_assert_eq!(coeff.modulus(), params.modulus().as_ref());
             coeffs_cxx.push(coeff.value().to_string());
         }
         Self::poly_gen_from_vec(params, coeffs_cxx)
@@ -147,71 +147,6 @@ impl Poly for DCRTPoly {
     }
 }
 
-impl Add for DCRTPoly {
-    type Output = Self;
-
-    fn add(self, rhs: Self) -> Self::Output {
-        self + &rhs
-    }
-}
-
-impl<'a> Add<&'a DCRTPoly> for DCRTPoly {
-    type Output = Self;
-
-    fn add(self, rhs: &'a Self) -> Self::Output {
-        DCRTPoly::new(ffi::DCRTPolyAdd(&rhs.ptr_poly, &self.ptr_poly))
-    }
-}
-
-impl Mul for DCRTPoly {
-    type Output = Self;
-
-    fn mul(self, rhs: Self) -> Self::Output {
-        self * &rhs
-    }
-}
-
-impl<'a> Mul<&'a DCRTPoly> for DCRTPoly {
-    type Output = Self;
-
-    fn mul(self, rhs: &'a Self) -> Self::Output {
-        &self * rhs
-    }
-}
-
-impl<'a> Mul<&'a DCRTPoly> for &'a DCRTPoly {
-    type Output = DCRTPoly;
-
-    fn mul(self, rhs: Self) -> Self::Output {
-        DCRTPoly::new(ffi::DCRTPolyMul(&rhs.ptr_poly, &self.ptr_poly))
-    }
-}
-
-impl Sub for DCRTPoly {
-    type Output = Self;
-
-    fn sub(self, rhs: Self) -> Self::Output {
-        self - &rhs
-    }
-}
-
-#[allow(clippy::suspicious_arithmetic_impl)]
-impl<'a> Sub<&'a DCRTPoly> for DCRTPoly {
-    type Output = Self;
-
-    fn sub(self, rhs: &'a Self) -> Self::Output {
-        self + rhs.clone().neg()
-    }
-}
-
-impl Neg for DCRTPoly {
-    type Output = Self;
-
-    fn neg(self) -> Self::Output {
-        DCRTPoly::new(self.ptr_poly.Negate())
-    }
-}
-
 impl PartialEq for DCRTPoly {
     fn eq(&self, other: &Self) -> bool {
         if self.ptr_poly.is_null() || other.ptr_poly.is_null() {
@@ -223,41 +158,108 @@ impl PartialEq for DCRTPoly {
 
 impl Eq for DCRTPoly {}
 
-impl AddAssign for DCRTPoly {
-    fn add_assign(&mut self, rhs: Self) {
-        self.ptr_poly = ffi::DCRTPolyAdd(&rhs.ptr_poly, &self.ptr_poly).into();
+/// Implements $tr for all combinations of T and &T by delegating to the &T/&T implementation.
+macro_rules! impl_binop_with_refs {
+    ($T:ty => $tr:ident::$f:ident $($t:tt)*) => {
+        impl $tr<$T> for $T {
+            type Output = $T;
+
+            #[inline]
+            fn $f(self, rhs: $T) -> Self::Output {
+                <&$T as $tr<&$T>>::$f(&self, &rhs)
+            }
+        }
+
+        impl $tr<&$T> for $T {
+            type Output = $T;
+
+            #[inline]
+            fn $f(self, rhs: &$T) -> Self::Output {
+                <&$T as $tr<&$T>>::$f(&self, rhs)
+            }
+        }
+
+        impl $tr<$T> for &$T {
+            type Output = $T;
+
+            #[inline]
+            fn $f(self, rhs: $T) -> Self::Output {
+                <&$T as $tr<&$T>>::$f(self, &rhs)
+            }
+        }
+
+        impl $tr<&$T> for &$T {
+            type Output = $T;
+
+            #[inline]
+            fn $f $($t)*
+        }
+    };
+}
+
+impl_binop_with_refs!(DCRTPoly => Add::add(self, rhs: &DCRTPoly) -> DCRTPoly {
+    DCRTPoly::new(ffi::DCRTPolyAdd(&rhs.ptr_poly, &self.ptr_poly))
+});
+
+impl_binop_with_refs!(DCRTPoly => Mul::mul(self, rhs: &DCRTPoly) -> DCRTPoly {
+    DCRTPoly::new(ffi::DCRTPolyMul(&rhs.ptr_poly, &self.ptr_poly))
+});
+
+impl_binop_with_refs!(DCRTPoly => Sub::sub(self, rhs: &DCRTPoly) -> DCRTPoly {
+    self + -rhs
+});
+
+impl Neg for DCRTPoly {
+    type Output = Self;
+
+    fn neg(self) -> Self::Output {
+        -&self
     }
 }
 
-impl<'a> AddAssign<&'a DCRTPoly> for DCRTPoly {
-    fn add_assign(&mut self, rhs: &'a Self) {
-        self.ptr_poly = ffi::DCRTPolyAdd(&rhs.ptr_poly, &self.ptr_poly).into();
+impl Neg for &DCRTPoly {
+    type Output = DCRTPoly;
+
+    fn neg(self) -> Self::Output {
+        DCRTPoly::new(self.ptr_poly.Negate())
+    }
+}
+
+impl AddAssign for DCRTPoly {
+    fn add_assign(&mut self, rhs: Self) {
+        *self += &rhs;
+    }
+}
+
+impl AddAssign<&DCRTPoly> for DCRTPoly {
+    fn add_assign(&mut self, rhs: &Self) {
+        // TODO: Expose `operator+=` in ffi.
+        *self = &*self + rhs;
     }
 }
 
 impl MulAssign for DCRTPoly {
     fn mul_assign(&mut self, rhs: Self) {
-        self.ptr_poly = ffi::DCRTPolyMul(&rhs.ptr_poly, &self.ptr_poly).into();
+        *self *= &rhs;
     }
 }
 
-impl<'a> MulAssign<&'a DCRTPoly> for DCRTPoly {
-    fn mul_assign(&mut self, rhs: &'a Self) {
-        self.ptr_poly = ffi::DCRTPolyMul(&rhs.ptr_poly, &self.ptr_poly).into();
+impl MulAssign<&DCRTPoly> for DCRTPoly {
+    fn mul_assign(&mut self, rhs: &Self) {
+        // TODO: Expose `operator*=` in ffi.
+        *self = &*self * rhs;
     }
 }
 
 impl SubAssign for DCRTPoly {
     fn sub_assign(&mut self, rhs: Self) {
-        let neg_rhs = rhs.neg();
-        self.ptr_poly = ffi::DCRTPolyAdd(&neg_rhs.ptr_poly, &self.ptr_poly).into();
+        *self -= &rhs;
     }
 }
 
-impl<'a> SubAssign<&'a DCRTPoly> for DCRTPoly {
-    fn sub_assign(&mut self, rhs: &'a Self) {
-        let neg_rhs = rhs.clone().neg();
-        self.ptr_poly = ffi::DCRTPolyAdd(&neg_rhs.ptr_poly, &self.ptr_poly).into();
+impl SubAssign<&DCRTPoly> for DCRTPoly {
+    fn sub_assign(&mut self, rhs: &Self) {
+        *self += -rhs;
     }
 }
 
@@ -270,8 +272,10 @@ mod tests {
     #[test]
     fn test_dcrtpoly_coeffs() {
         let mut rng = rand::rng();
-        // todo: if x=0, n=1: libc++abi: terminating due to uncaught exception of type lbcrypto::OpenFHEException: /Users/piapark/Documents/GitHub/openfhe-development/src/core/include/math/nbtheory.h:l.156:ReverseBits(): msbb value not handled:0
-        // todo: if x=1, n=2: value mismatch from_coeffs & coeffs
+        /*
+        todo: if x=0, n=1: libc++abi: terminating due to uncaught exception of type lbcrypto::OpenFHEException: /Users/piapark/Documents/GitHub/openfhe-development/src/core/include/math/nbtheory.h:l.156:ReverseBits(): msbb value not handled:0
+        todo: if x=1, n=2: value mismatch from_coeffs & coeffs
+        */
         let x = rng.random_range(12..20);
         let size = rng.random_range(1..20);
         let n = 2_i32.pow(x) as u32;

--- a/src/poly/dcrt/sampler/hash.rs
+++ b/src/poly/dcrt/sampler/hash.rs
@@ -168,13 +168,15 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-
     use super::*;
     use crate::poly::dcrt::DCRTPolyParams;
+    #[cfg(not(feature = "parallel"))]
     use itertools::Itertools;
     use keccak_asm::Keccak256;
+    #[cfg(not(feature = "parallel"))]
     use proptest::prelude::*;
+    #[cfg(not(feature = "parallel"))]
+    use std::sync::Arc;
 
     #[test]
     fn test_poly_hash_sampler() {
@@ -213,6 +215,7 @@ mod tests {
         assert_eq!(matrix.col_size(), ncol, "Matrix column count mismatch");
     }
 
+    #[cfg(not(feature = "parallel"))]
     proptest! {
         #![proptest_config(ProptestConfig::with_cases(10))]
 

--- a/src/poly/dcrt/sampler/uniform.rs
+++ b/src/poly/dcrt/sampler/uniform.rs
@@ -78,9 +78,13 @@ impl PolyUniformSampler for DCRTPolyUniformSampler {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(not(feature = "parallel"))]
     use itertools::Itertools;
+    #[cfg(not(feature = "parallel"))]
     use num_bigint::BigUint;
+    #[cfg(not(feature = "parallel"))]
     use proptest::prelude::*;
+    #[cfg(not(feature = "parallel"))]
     use std::sync::Arc;
 
     #[test]
@@ -164,6 +168,7 @@ mod tests {
         assert_eq!(mult_matrix.col_size(), 12);
     }
 
+    #[cfg(not(feature = "parallel"))]
     proptest::proptest! {
         #![proptest_config(ProptestConfig::with_cases(10))]
 

--- a/src/poly/dcrt/sampler/uniform.rs
+++ b/src/poly/dcrt/sampler/uniform.rs
@@ -68,14 +68,11 @@ impl PolyUniformSampler for DCRTPolyUniformSampler {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-
-    use crate::poly::PolyParams;
-
     use super::*;
     use itertools::Itertools;
     use num_bigint::BigUint;
     use proptest::prelude::*;
+    use std::sync::Arc;
 
     #[test]
     fn test_ring_dist() {

--- a/src/poly/dcrt/sampler/uniform.rs
+++ b/src/poly/dcrt/sampler/uniform.rs
@@ -52,16 +52,20 @@ impl PolyUniformSampler for DCRTPolyUniformSampler {
         columns: usize,
         dist: DistType,
     ) -> Self::M {
-        let mut c: Vec<Vec<DCRTPoly>> = vec![vec![DCRTPoly::const_zero(params); columns]; rows];
-        for row in 0..rows {
-            for col in 0..columns {
+        let mut c: Vec<Vec<DCRTPoly>> = Vec::with_capacity(rows);
+        for _ in 0..rows {
+            let mut row_vec = Vec::with_capacity(columns);
+            for _ in 0..columns {
                 let sampled_poly = self.sample_poly(params, &dist);
                 if sampled_poly.get_poly().is_null() {
                     panic!("Attempted to dereference a null pointer");
                 }
-                c[row][col] = sampled_poly;
+                row_vec.push(sampled_poly);
             }
+
+            c.push(row_vec);
         }
+
         DCRTPolyMatrix::from_poly_vec(params, c)
     }
 }

--- a/src/poly/matrix.rs
+++ b/src/poly/matrix.rs
@@ -91,6 +91,6 @@ pub trait PolyMatrix:
         new_modulus: &<<Self::P as Poly>::Params as PolyParams>::Modulus,
     ) -> Self;
 
-    /// Performs the operation S * (other ⊗ identity)
+    /// Performs the operation S * (identity ⊗ other)
     fn mul_tensor_identity(&self, other: &Self, identity_size: usize) -> Self;
 }

--- a/src/poly/matrix.rs
+++ b/src/poly/matrix.rs
@@ -90,4 +90,7 @@ pub trait PolyMatrix:
         &self,
         new_modulus: &<<Self::P as Poly>::Params as PolyParams>::Modulus,
     ) -> Self;
+
+    /// Performs the operation S * (other ⊗ identity)
+    fn mul_tensor_identity(&self, other: &Self, identity_size: usize) -> Self;
 }

--- a/src/poly/mod.rs
+++ b/src/poly/mod.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::needless_range_loop)]
+#![allow(clippy::suspicious_arithmetic_impl)]
 
 pub mod dcrt;
 pub mod element;

--- a/src/poly/params.rs
+++ b/src/poly/params.rs
@@ -1,7 +1,8 @@
 use std::fmt::Debug;
-pub trait PolyParams: Clone + Debug {
+pub trait PolyParams: Clone + Debug + Send + Sync {
     type Modulus: Debug + Clone;
-    /// Returns the modulus value `q` used for polynomial coefficients in the ring `Z_q[x]/(x^n - 1)`.
+    /// Returns the modulus value `q` used for polynomial coefficients in the ring `Z_q[x]/(x^n -
+    /// 1)`.
     fn modulus(&self) -> Self::Modulus;
     /// Fewest bits necessary to represent the modulus value `q`.
     fn modulus_bits(&self) -> usize;

--- a/src/poly/sampler.rs
+++ b/src/poly/sampler.rs
@@ -3,7 +3,8 @@ use super::{Poly, PolyMatrix};
 #[derive(Debug)]
 /// Enum representing different types of distributions for random sampling.
 pub enum DistType {
-    /// Distribution over a finite ring, typically samples elements from a ring in a uniform or near-uniform manner
+    /// Distribution over a finite ring, typically samples elements from a ring in a uniform or
+    /// near-uniform manner
     FinRingDist,
     /// discrete Gaussian distribution described in [[GPV08](https://eprint.iacr.org/2007/432),[BDJ+24](https://eprint.iacr.org/2024/1742)], where
     /// noise is drawn from a discrete Gaussian over a lattice Λ with parameter σ > 0.
@@ -18,7 +19,8 @@ pub enum DistType {
 /// Trait for sampling a polynomial based on a hash function.
 pub trait PolyHashSampler<K: AsRef<[u8]>> {
     type M: PolyMatrix;
-    /// Samples a matrix of ring elements from a pseudorandom source defined by a hash function `H` Compute H(key || tag || i)
+    /// Samples a matrix of ring elements from a pseudorandom source defined by a hash function `H`
+    /// Compute H(key || tag || i)
     ///
     /// and a distribution type specified by `dist`.
     fn sample_hash<B: AsRef<[u8]>>(
@@ -48,7 +50,7 @@ pub trait PolyUniformSampler {
 
 pub trait PolyTrapdoorSampler {
     type M: PolyMatrix;
-    type Trapdoor;
+    type Trapdoor: Send + Sync;
 
     fn trapdoor(
         &self,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,11 +1,10 @@
-use num_bigint::BigUint;
-use num_traits::{One, Zero};
-
 use crate::poly::{
     dcrt::{DCRTPoly, DCRTPolyParams, DCRTPolyUniformSampler},
     sampler::DistType,
     Poly,
 };
+use num_bigint::BigUint;
+use num_traits::{One, Zero};
 
 pub fn ceil_log2(q: &BigUint) -> usize {
     assert!(!q.is_zero(), "log2 is undefined for zero");

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -3,6 +3,7 @@ use crate::poly::{
     sampler::DistType,
     Poly,
 };
+use memory_stats::memory_stats;
 use num_bigint::BigUint;
 use num_traits::{One, Zero};
 
@@ -67,6 +68,14 @@ pub fn create_bit_poly(params: &DCRTPolyParams, bit: bool) -> DCRTPoly {
         DCRTPoly::const_one(params)
     } else {
         DCRTPoly::const_zero(params)
+    }
+}
+
+pub fn print_memory_usage(label: &str) {
+    if let Some(usage) = memory_stats() {
+        println!("{}: {} bytes", label, usage.physical_mem);
+    } else {
+        println!("Couldn't get memory stats!");
     }
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -83,11 +83,26 @@ pub fn print_memory_usage(label: &str) {
 macro_rules! parallel_iter {
     ($i: expr) => {{
         #[cfg(not(feature = "parallel"))]
-        let iter = $i.into_iter();
-
+        {
+            IntoIterator::into_iter($i)
+        }
         #[cfg(feature = "parallel")]
-        let iter = $i.into_par_iter();
+        {
+            rayon::iter::IntoParallelIterator::into_par_iter($i)
+        }
+    }};
+}
 
-        iter
+#[macro_export]
+macro_rules! join {
+    ($a:expr, $b:expr $(,)?) => {{
+        #[cfg(not(feature = "parallel"))]
+        {
+            ($a(), $b())
+        }
+        #[cfg(feature = "parallel")]
+        {
+            rayon::join($a, $b)
+        }
     }};
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -70,3 +70,16 @@ pub fn create_bit_poly(params: &DCRTPolyParams, bit: bool) -> DCRTPoly {
         DCRTPoly::const_zero(params)
     }
 }
+
+#[macro_export]
+macro_rules! parallel_iter {
+    ($i: expr) => {{
+        #[cfg(not(feature = "parallel"))]
+        let iter = $i.into_iter();
+
+        #[cfg(feature = "parallel")]
+        let iter = $i.into_par_iter();
+
+        iter
+    }};
+}


### PR DESCRIPTION
Core idea: I have a `S` matrix of size 2x12, `other` matrix of size 3x3 and identity `I` matrix of size 4x4. Goal is to perform `S * (I ⊗ other)`.

Current implementation: First perform `partial = (I ⊗ other)` and then `out = S * partial`.

Optimized implementation: Directly compute `out = S1*other | S2*other | S3*other | S4*other` where each `Si` is the slice of `S` of size 2 x 3

Results:

Reduced peak memory consumption from 4.78 GB to 353 MB

Improved performance

Before
```
Time to obfuscate: 139.643509375s
Time for evaluation: 102.822680333s
Total time: 242.466189708s
```

After
```
Time to obfuscate: 105.465769375s
Time for evaluation: 86.621996s
Total time: 192.087765375s
```