### PR TITLE
feat: apply tensor optimization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ num-traits = "0.2"
 rayon = "1.5"
 rand = { version = "0.9.0", features = ["std_rng"] }
 itertools = "0.14.0"
+memory-stats = "1.0.0"
 
 [dev-dependencies]
 keccak-asm = { version = "0.1.4" }

--- a/src/io/eval.rs
+++ b/src/io/eval.rs
@@ -80,9 +80,14 @@ where
         //     2 * log_q * (packed_input_size + 3),
         // );
         let new_encode_vec = {
-            let t = if *input { &public_data.ts[1] } else { &public_data.ts[0] };
+            let t = if *input {
+                &public_data.rgs_decomposed[1]
+            } else {
+                &public_data.rgs_decomposed[0]
+            };
             let encode_vec = encodings[idx][0].concat_vector(&encodings[idx][1..]);
-            encode_vec * t + v
+            let packed_input_size = log_q + obf_params.input_size.div_ceil(dim) + 1;
+            encode_vec.mul_tensor_identity(t, packed_input_size + 1) + v
         };
         let mut new_encodings = vec![];
         // let zero_poly = <M::P as Poly>::const_zero(&params);

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -57,6 +57,7 @@ mod test {
 
     #[test]
     fn test_io_just_mul_enc_and_bit() {
+        let start_time = std::time::Instant::now();
         let params = DCRTPolyParams::default();
         let log_q = params.modulus_bits();
         let switched_modulus = Arc::new(BigUint::from(1u32));
@@ -91,7 +92,8 @@ mod test {
             sampler_trapdoor,
             &mut rng,
         );
-        println!("obfuscated");
+        let obfuscation_time = start_time.elapsed();
+        println!("Time to obfuscate: {:?}", obfuscation_time);
         let input = [true];
         let sampler_hash = DCRTPolyHashSampler::<Keccak256>::new([0; 32]);
         let hardcoded_key = obfuscation
@@ -102,7 +104,10 @@ mod test {
             .map(|elem| elem.value() != &BigUint::from(0u8))
             .collect::<Vec<_>>();
         let output = eval_obf(obf_params, sampler_hash, obfuscation, &input);
+        let total_time = start_time.elapsed();
         println!("{:?}", output);
+        println!("Time for evaluation: {:?}", total_time - obfuscation_time);
+        println!("Total time: {:?}", total_time);
         assert_eq!(output, hardcoded_key);
     }
 }

--- a/src/io/obf.rs
+++ b/src/io/obf.rs
@@ -132,9 +132,9 @@ where
 
         let mut ks = vec![];
         for bit in 0..2 {
-            let t = &public_data.ts[bit];
-            let top =
-                -public_data.pubkeys[idx][0].concat_matrix(&public_data.pubkeys[idx][1..]) * t;
+            let rg_decomposed = &public_data.rgs_decomposed[bit];
+            let lhs = -public_data.pubkeys[idx][0].concat_matrix(&public_data.pubkeys[idx][1..]);
+            let top = lhs.mul_tensor_identity(rg_decomposed, 1 + packed_input_size);
             let inserted_poly_index = 1 + log_q + idx / dim;
             let inserted_coeff_index = idx % dim;
             let zero_coeff = <M::P as Poly>::Elem::zero(&params.modulus());

--- a/src/io/utils.rs
+++ b/src/io/utils.rs
@@ -19,7 +19,7 @@ pub struct PublicSampledData<S: PolyHashSampler<[u8; 32]>> {
     pub a_rlwe_bar: S::M,
     pub pubkeys: Vec<Vec<BggPublicKey<S::M>>>,
     // pub pubkeys_fhe_key: Vec<Vec<BggPublicKey<S::M>>>,
-    pub ts: [S::M; 2],
+    pub rgs_decomposed: [S::M; 2],
     pub a_prf: S::M,
     pub packed_input_size: usize,
     pub packed_output_size: usize,
@@ -71,16 +71,15 @@ impl<S: PolyHashSampler<[u8; 32]>> PublicSampledData<S> {
         let identity_input = S::M::identity(params, 1 + packed_input_size, None);
         let gadget_2 = S::M::gadget_matrix(params, 2);
         // let identity_2 = S::M::identity(params, 2, None);
-        let mut ts = vec![];
+        let mut rgs_decomposed = vec![];
         for bit in 0..2 {
             let r = if bit == 0 { r_0.clone() } else { r_1.clone() };
             let rg = r * &gadget_2;
             let rg_decomposed = rg.decompose();
-            let t = identity_input.clone().tensor(&rg_decomposed);
             // let t_fhe_key = identity_2.clone().tensor(&rg_decomposed);
-            ts.push(t);
+            rgs_decomposed.push(rg_decomposed);
         }
-        let ts = ts.try_into().unwrap();
+        let rgs_decomposed = rgs_decomposed.try_into().unwrap();
         let a_prf_raw = hash_sampler.sample_hash(
             params,
             TAG_A_PRF,
@@ -94,7 +93,7 @@ impl<S: PolyHashSampler<[u8; 32]>> PublicSampledData<S> {
             r_1,
             a_rlwe_bar,
             pubkeys,
-            ts,
+            rgs_decomposed,
             a_prf,
             packed_input_size,
             packed_output_size,

--- a/src/poly/dcrt/matrix.rs
+++ b/src/poly/dcrt/matrix.rs
@@ -305,6 +305,18 @@ impl PolyMatrix for DCRTPolyMatrix {
         }
         Self { inner: new_inner, params: self.params.clone(), nrow: self.nrow, ncol: self.ncol }
     }
+
+    fn mul_tensor_identity(&self, other: &Self, identity_size: usize) -> Self {
+        assert_eq!(self.ncol, other.nrow * identity_size);
+        let slice_width = other.nrow;
+        let mut slice_results = Vec::with_capacity(identity_size);
+        for i in 0..identity_size {
+            let slice = self.slice(0, self.nrow, i * slice_width, (i + 1) * slice_width);
+            let slice_result = slice * other;
+            slice_results.push(slice_result);
+        }
+        slice_results[0].clone().concat_columns(&slice_results[1..])
+    }
 }
 
 // ====== Arithmetic ======
@@ -464,7 +476,10 @@ mod tests {
     use num_bigint::BigUint;
 
     use super::*;
-    use crate::poly::dcrt::DCRTPolyParams;
+    use crate::poly::{
+        dcrt::{DCRTPolyParams, DCRTPolyUniformSampler},
+        sampler::PolyUniformSampler,
+    };
 
     #[test]
     fn test_gadget_matrix() {
@@ -643,5 +658,34 @@ mod tests {
         let matrix1 = DCRTPolyMatrix::zero(&params, 2, 2);
         let matrix2 = DCRTPolyMatrix::zero(&params, 3, 2);
         let _prod = matrix1 * matrix2;
+    }
+
+    #[test]
+    fn test_mul_tensor_identity() {
+        let params = DCRTPolyParams::default();
+        let sampler = DCRTPolyUniformSampler::new();
+
+        // Create matrix S (2x12)
+        let s = sampler.sample_uniform(&params, 2, 12, crate::poly::sampler::DistType::FinRingDist);
+
+        // Create 'other' matrix (3x3)
+        let other =
+            sampler.sample_uniform(&params, 3, 3, crate::poly::sampler::DistType::FinRingDist);
+
+        // Perform S * (I_4 ⊗ other)
+        let result = s.mul_tensor_identity(&other, 4);
+
+        // Check dimensions
+        assert_eq!(result.row_size(), 2);
+        assert_eq!(result.col_size(), 12);
+
+        let identity = DCRTPolyMatrix::identity(&params, 4, None);
+
+        // Check result
+        let expected_result = s * (identity.tensor(&other));
+
+        assert_eq!(expected_result.row_size(), 2);
+        assert_eq!(expected_result.col_size(), 12);
+        assert_eq!(result, expected_result)
     }
 }

--- a/src/poly/dcrt/matrix.rs
+++ b/src/poly/dcrt/matrix.rs
@@ -312,8 +312,7 @@ impl PolyMatrix for DCRTPolyMatrix {
         let mut slice_results = Vec::with_capacity(identity_size);
         for i in 0..identity_size {
             let slice = self.slice(0, self.nrow, i * slice_width, (i + 1) * slice_width);
-            let slice_result = slice * other;
-            slice_results.push(slice_result);
+            slice_results.push(slice * other);
         }
         slice_results[0].clone().concat_columns(&slice_results[1..])
     }

--- a/src/poly/matrix.rs
+++ b/src/poly/matrix.rs
@@ -90,4 +90,6 @@ pub trait PolyMatrix:
         &self,
         new_modulus: &<<Self::P as Poly>::Params as PolyParams>::Modulus,
     ) -> Self;
+    /// Performs the operation S * (identity ⊗ other)
+    fn mul_tensor_identity(&self, other: &Self, identity_size: usize) -> Self;
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,11 +1,11 @@
-use num_bigint::BigUint;
-use num_traits::{One, Zero};
-
 use crate::poly::{
     dcrt::{DCRTPoly, DCRTPolyParams, DCRTPolyUniformSampler},
     sampler::DistType,
     Poly,
 };
+use memory_stats::memory_stats;
+use num_bigint::BigUint;
+use num_traits::{One, Zero};
 
 pub fn ceil_log2(q: &BigUint) -> usize {
     assert!(!q.is_zero(), "log2 is undefined for zero");
@@ -68,5 +68,13 @@ pub fn create_bit_poly(params: &DCRTPolyParams, bit: bool) -> DCRTPoly {
         DCRTPoly::const_one(params)
     } else {
         DCRTPoly::const_zero(params)
+    }
+}
+
+pub fn print_memory_usage(label: &str) {
+    if let Some(usage) = memory_stats() {
+        println!("{}: {} bytes", label, usage.physical_mem);
+    } else {
+        println!("Couldn't get memory stats!");
     }
 }


### PR DESCRIPTION
Core idea: I have a `S` matrix of size 2x12, `other` matrix of size 3x3 and identity `I` matrix of size 4x4. Goal is to perform `S * (I ⊗ other)`.

Current implementation: First perform `partial = (I ⊗ other)` and then `out = S * partial`.

Optimized implementation: Directly compute `out = S1*other | S2*other | S3*other | S4*other` where each `Si` is the slice of `S` of size 2 x 3

Results after running `/usr/bin/time -l cargo test test_io_just_mul_enc_and_bit --release  -- --nocapture`

Before
```
Peak memory consumptions 4801904640  bytes (4.47 GB)
Time to obfuscate: 132.466593875s
Time for evaluation: 129.248957959s
Total time: 261.715551834s
```

After
```
Peak memory consumptions 542539776  bytes (0.51 GB)
Time to obfuscate: 105.465769375s
Time for evaluation: 116.751426959s
Total time: 220.925412584s
```