### PR TITLE
chore:  nightly, ci split, rust cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    strategy:
+        fail-fast: false
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
@@ -74,7 +76,7 @@ jobs:
 
       - name: Verify OpenFHE libraries
         run: |
-          if [ -z "$(ls -A /usr/local/lib | grep openfhe)" ]; then
+          if [ -z "$(ls -A /usr/local/lib | grep OpenFHE)" ]; then
             echo "OpenFHE libraries missing! Reinstalling..."
             cd openfhe/build
             sudo make install
@@ -88,7 +90,7 @@ jobs:
           sudo ldconfig
 
       - name: Verify OpenFHE installation
-        run: ls -lah /usr/local/lib | grep openfhe
+        run: ls -lah /usr/local/lib | grep OpenFHE
           
       - name: Run clippy
         run: cargo +nightly clippy --workspace --all-targets --all-features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
         id: openfhe-install-cache
         uses: actions/cache@v4
         with:
-          path: /usr/local/lib
+          path: /usr/local/lib/OpenFHE
           key: ${{ runner.os }}-openfhe-install-${{ hashFiles('openfhe/CMakeLists.txt') }}
 
       - name: Build OpenFHE

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,9 @@ jobs:
         with:
           components: clippy
 
+      - name: Cache Rust artifacts
+        uses: Swatinem/rust-cache@v2
+
       - name: Install dependencies
         run: |
           sudo apt-get update
@@ -60,8 +63,6 @@ jobs:
           path: /usr/local/lib
           key: ${{ runner.os }}-openfhe-install-${{ hashFiles('openfhe/CMakeLists.txt') }}
 
-
-
       - name: Build OpenFHE
         if: steps.openfhe-cache.outputs.cache-hit != 'true'
         run: |
@@ -70,6 +71,16 @@ jobs:
           cmake ..
           make -j"$(nproc)"
           sudo make install
+
+      - name: Verify OpenFHE libraries
+        run: |
+          if [ -z "$(ls -A /usr/local/lib | grep openfhe)" ]; then
+            echo "OpenFHE libraries missing! Reinstalling..."
+            cd openfhe/build
+            sudo make install
+          else
+            echo "OpenFHE libraries found, skipping install."
+          fi
 
       - name: Update dynamic linker cache
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,11 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
+
+      - name: Update dynamic linker cache
+        run: |
+          echo "/usr/local/lib" | sudo tee /etc/ld.so.conf.d/openfhe.conf
+          sudo ldconfig
       - run: cargo +nightly clippy --workspace --all-targets --all-features
         env:
           RUSTFLAGS: -A unused
@@ -90,6 +95,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
+
+      - name: Update dynamic linker cache
+        run: |
+          echo "/usr/local/lib" | sudo tee /etc/ld.so.conf.d/openfhe.conf
+          sudo ldconfig
 
       - name: Cache Rust dependencies
         uses: actions/cache@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,6 @@ jobs:
           
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
     strategy:
         fail-fast: false
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,9 +45,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: openfhe/build
-          key: ${{ runner.os }}-openfhe-${{ hashFiles('openfhe/CMakeLists.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-openfhe-
+          key: ${{ runner.os }}-openfhe-${{ hashFiles('openfhe/**/CMakeLists.txt') }}
 
       - name: Checkout OpenFHE
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
           components: rustfmt
       - run: cargo +nightly fmt --all --check
           
-  build:
+  test:
     runs-on: ubuntu-latest
     strategy:
         fail-fast: false
@@ -35,6 +35,9 @@ jobs:
       - uses: dtolnay/rust-toolchain@nightly
         with:
           components: clippy
+
+      - name: Cache Rust artifacts
+        uses: Swatinem/rust-cache@v2
 
       - name: Install dependencies
         run: |
@@ -63,36 +66,10 @@ jobs:
       - name: Verify OpenFHE installation
         run: ls -lah /usr/local/lib | grep OpenFHE
 
-  clippy:
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    needs:
-      - build
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@nightly
-        with:
-          components: clippy
-
-      - name: Cache Rust artifacts
-        uses: Swatinem/rust-cache@v2
-
       - name: Run clippy
         run: cargo +nightly clippy --workspace --all-targets --all-features
         env:
           RUSTFLAGS: -A unused
-
-  test:
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    needs:
-      - build
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@nightly
-
-      - name: Cache Rust artifacts
-        uses: Swatinem/rust-cache@v2
 
       - name: Run test
         run: cargo test --features="parallel"
@@ -102,7 +79,6 @@ jobs:
     runs-on: ubuntu-latest
     if: always()
     needs:
-      - clippy
       - test
       - fmt
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     needs:
-      - test
+      - build
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
@@ -42,26 +42,17 @@ jobs:
       - run: cargo +nightly clippy --workspace --all-targets --all-features
         env:
           RUSTFLAGS: -A unused
-
-  test:
+          
+  build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@nightly
 
       - name: Install dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y build-essential cmake libgmp-dev
-
-      - name: Cache Rust dependencies
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Cache OpenFHE build
         id: openfhe-cache
@@ -91,6 +82,23 @@ jobs:
         run: |
           echo "/usr/local/lib" | sudo tee /etc/ld.so.conf.d/openfhe.conf
           sudo ldconfig
+
+  test:
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
+
+      - name: Cache Rust dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Run test
         run: cargo test --features="parallel"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,7 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Cache OpenFHE build
+        id: openfhe-cache
         uses: actions/cache@v4
         with:
           path: openfhe/build
@@ -78,6 +79,7 @@ jobs:
           path: openfhe
 
       - name: Build OpenFHE
+        if: steps.openfhe-cache.outputs.cache-hit != 'true'
         run: |
           cd openfhe
           mkdir -p build && cd build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,12 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y build-essential cmake libgmp-dev
 
+      - name: Checkout OpenFHE
+        uses: actions/checkout@v4
+        with:
+          repository: openfheorg/openfhe-development
+          path: openfhe
+
       - name: Cache OpenFHE build
         id: openfhe-cache
         uses: actions/cache@v4
@@ -54,12 +60,7 @@ jobs:
           path: /usr/local/lib
           key: ${{ runner.os }}-openfhe-install-${{ hashFiles('openfhe/CMakeLists.txt') }}
 
-      - name: Checkout OpenFHE
-        if: steps.openfhe-cache.outputs.cache-hit != 'true'
-        uses: actions/checkout@v4
-        with:
-          repository: openfheorg/openfhe-development
-          path: openfhe
+
 
       - name: Build OpenFHE
         if: steps.openfhe-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,9 +36,6 @@ jobs:
         with:
           components: clippy
 
-      - name: Cache Rust artifacts
-        uses: Swatinem/rust-cache@v2
-
       - name: Install dependencies
         run: |
           sudo apt-get update
@@ -50,38 +47,13 @@ jobs:
           repository: openfheorg/openfhe-development
           path: openfhe
 
-      - name: Cache OpenFHE build
-        id: openfhe-cache
-        uses: actions/cache@v4
-        with:
-          path: openfhe/build
-          key: ${{ runner.os }}-openfhe-${{ hashFiles('openfhe/CMakeLists.txt') }}
-
-      - name: Cache OpenFHE installation
-        id: openfhe-install-cache
-        uses: actions/cache@v4
-        with:
-          path: /usr/local/lib/OpenFHE
-          key: ${{ runner.os }}-openfhe-install-${{ hashFiles('openfhe/CMakeLists.txt') }}
-
       - name: Build OpenFHE
-        if: steps.openfhe-cache.outputs.cache-hit != 'true'
         run: |
           cd openfhe
           mkdir -p build && cd build
           cmake ..
           make -j"$(nproc)"
           sudo make install
-
-      - name: Verify OpenFHE libraries
-        run: |
-          if [ -z "$(ls -A /usr/local/lib | grep OpenFHE)" ]; then
-            echo "OpenFHE libraries missing! Reinstalling..."
-            cd openfhe/build
-            sudo make install
-          else
-            echo "OpenFHE libraries found, skipping install."
-          fi
 
       - name: Update dynamic linker cache
         run: |
@@ -90,11 +62,37 @@ jobs:
 
       - name: Verify OpenFHE installation
         run: ls -lah /usr/local/lib | grep OpenFHE
-          
+
+  clippy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs:
+      - build
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: clippy
+
+      - name: Cache Rust artifacts
+        uses: Swatinem/rust-cache@v2
+
       - name: Run clippy
         run: cargo +nightly clippy --workspace --all-targets --all-features
         env:
           RUSTFLAGS: -A unused
+
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs:
+      - build
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
+
+      - name: Cache Rust artifacts
+        uses: Swatinem/rust-cache@v2
 
       - name: Run test
         run: cargo test --features="parallel"
@@ -104,7 +102,8 @@ jobs:
     runs-on: ubuntu-latest
     if: always()
     needs:
-      - build
+      - clippy
+      - test
       - fmt
     steps:
       - name: Decide whether the needed jobs succeeded or failed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,28 +25,6 @@ jobs:
         with:
           components: rustfmt
       - run: cargo +nightly fmt --all --check
-
-  clippy:
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    needs:
-      - build
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@nightly
-        with:
-          components: clippy
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
-
-      - name: Update dynamic linker cache
-        run: |
-          echo "/usr/local/lib" | sudo tee /etc/ld.so.conf.d/openfhe.conf
-          sudo ldconfig
-      - run: cargo +nightly clippy --workspace --all-targets --all-features
-        env:
-          RUSTFLAGS: -A unused
           
   build:
     runs-on: ubuntu-latest
@@ -87,43 +65,21 @@ jobs:
         run: |
           echo "/usr/local/lib" | sudo tee /etc/ld.so.conf.d/openfhe.conf
           sudo ldconfig
-
-  test:
-    runs-on: ubuntu-latest
-    needs:
-      - build
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@nightly
-
-      - name: Update dynamic linker cache
-        run: |
-          echo "/usr/local/lib" | sudo tee /etc/ld.so.conf.d/openfhe.conf
-          sudo ldconfig
-
-      - name: Cache Rust dependencies
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          
+      - name: Run clippy
+      - run: cargo +nightly clippy --workspace --all-targets --all-features
+        env:
+          RUSTFLAGS: -A unused
 
       - name: Run test
         run: cargo test --features="parallel"
-        env:
-          CXXFLAGS: "-I/usr/local/include -I/usr/local/include/openfhe -I/usr/local/include/openfhe/core"
-          LDFLAGS: "-L/usr/local/lib"
-          RUSTFLAGS: "-C link-args=-L/usr/local/lib"
   
   ci-success:
     name: ci success
     runs-on: ubuntu-latest
     if: always()
     needs:
-      - test
-      - clippy
+      - build
       - fmt
     steps:
       - name: Decide whether the needed jobs succeeded or failed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
           sudo ldconfig
           
       - name: Run clippy
-      - run: cargo +nightly clippy --workspace --all-targets --all-features
+        run: cargo +nightly clippy --workspace --all-targets --all-features
         env:
           RUSTFLAGS: -A unused
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
   clippy:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    needs:
+      - test
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
@@ -53,7 +55,7 @@ jobs:
           sudo apt-get install -y build-essential cmake libgmp-dev
 
       - name: Cache Rust dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
@@ -62,7 +64,7 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Cache OpenFHE build
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: openfhe/build
           key: ${{ runner.os }}-openfhe-${{ hashFiles('openfhe/CMakeLists.txt') }}
@@ -70,7 +72,7 @@ jobs:
             ${{ runner.os }}-openfhe-
 
       - name: Checkout OpenFHE
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: openfheorg/openfhe-development
           path: openfhe

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
       - name: Run test
         run: cargo test --features="parallel"
         env:
-          CXXFLAGS: "-I/usr/local/include"
+          CXXFLAGS: "-I/usr/local/include -I/usr/local/include/openfhe -I/usr/local/include/openfhe/core"
           LDFLAGS: "-L/usr/local/lib"
           RUSTFLAGS: "-C link-args=-L/usr/local/lib"
   

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@nightly
         with:
           components: rustfmt
-      - run: cargo fmt --all --check
+      - run: cargo +nightly fmt --all --check
 
   clippy:
     runs-on: ubuntu-latest
@@ -37,7 +37,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
-      - run: cargo clippy --workspace --all-targets --all-features
+      - run: cargo +nightly clippy --workspace --all-targets --all-features
         env:
           RUSTFLAGS: -A unused
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,10 @@ jobs:
 
       - name: Run test
         run: cargo test --features="parallel"
+        env:
+          CXXFLAGS: "-I/usr/local/include"
+          LDFLAGS: "-L/usr/local/lib"
+          RUSTFLAGS: "-C link-args=-L/usr/local/lib"
   
   ci-success:
     name: ci success

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: clippy
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,15 +8,44 @@ on:
     branches:
       - main
 
+env:
+  CARGO_TERM_COLOR: always
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
+  fmt:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rustfmt
+      - run: cargo fmt --all --check
+
+  clippy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+      - run: cargo clippy --workspace --all-targets --all-features
+        env:
+          RUSTFLAGS: -A unused
+
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: stable
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
 
       - name: Install dependencies
         run: |
@@ -59,12 +88,19 @@ jobs:
           echo "/usr/local/lib" | sudo tee /etc/ld.so.conf.d/openfhe.conf
           sudo ldconfig
 
-      - uses: taiki-e/install-action@cargo-llvm-cov
-      - uses: taiki-e/install-action@nextest
-      - name: Install clippy and rustfmt
-        run: |
-          rustup component add clippy
-          rustup component add rustfmt
-      - uses: taiki-e/install-action@just
-      - name: Run ci
-        run: just ci
+      - name: Run test
+        run: cargo test --features="parallel"
+  
+  ci-success:
+    name: ci success
+    runs-on: ubuntu-latest
+    if: always()
+    needs:
+      - test
+      - clippy
+      - fmt
+    steps:
+      - name: Decide whether the needed jobs succeeded or failed
+        uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,10 +44,11 @@ jobs:
         id: openfhe-cache
         uses: actions/cache@v4
         with:
-          path: openfhe/build
+          path: openfhe
           key: ${{ runner.os }}-openfhe-${{ hashFiles('openfhe/**/CMakeLists.txt') }}
 
       - name: Checkout OpenFHE
+        if: steps.openfhe-cache.outputs.cache-hit != 'true'
         uses: actions/checkout@v4
         with:
           repository: openfheorg/openfhe-development

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,8 +44,15 @@ jobs:
         id: openfhe-cache
         uses: actions/cache@v4
         with:
-          path: openfhe
-          key: ${{ runner.os }}-openfhe-${{ hashFiles('openfhe/**/CMakeLists.txt') }}
+          path: openfhe/build
+          key: ${{ runner.os }}-openfhe-${{ hashFiles('openfhe/CMakeLists.txt') }}
+
+      - name: Cache OpenFHE installation
+        id: openfhe-install-cache
+        uses: actions/cache@v4
+        with:
+          path: /usr/local/lib
+          key: ${{ runner.os }}-openfhe-install-${{ hashFiles('openfhe/CMakeLists.txt') }}
 
       - name: Checkout OpenFHE
         if: steps.openfhe-cache.outputs.cache-hit != 'true'
@@ -67,6 +74,9 @@ jobs:
         run: |
           echo "/usr/local/lib" | sudo tee /etc/ld.so.conf.d/openfhe.conf
           sudo ldconfig
+
+      - name: Verify OpenFHE installation
+        run: ls -lah /usr/local/lib | grep openfhe
           
       - name: Run clippy
         run: cargo +nightly clippy --workspace --all-targets --all-features

--- a/benches/dcrtmatrix.rs
+++ b/benches/dcrtmatrix.rs
@@ -1,7 +1,8 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
-use diamond_io::poly::dcrt::DCRTPolyMatrix;
-use diamond_io::poly::dcrt::DCRTPolyParams;
-use diamond_io::poly::PolyMatrix;
+use diamond_io::poly::{
+    dcrt::{DCRTPolyMatrix, DCRTPolyParams},
+    PolyMatrix,
+};
 
 fn bench_matrix_operation(c: &mut Criterion) {
     let params = DCRTPolyParams::new(4, 2, 17);

--- a/justfile
+++ b/justfile
@@ -3,7 +3,7 @@ export CARGO_MAKE_EXTEND_WORKSPACE_MAKEFILE := "true"
 
 # Run rustfmt to check the code formatting without making changes
 format:
-    cargo fmt -- --check
+    cargo +nightly fmt -- --check
 
 # Clean up the project by removing the target directory
 clean:

--- a/justfile
+++ b/justfile
@@ -11,7 +11,7 @@ clean:
 
 # Run clippy to catch common mistakes and improve your Rust code
 clippy:
-    RUSTFLAGS="-A unused" cargo clippy --all-targets --all-features -- -Dwarnings
+    RUSTFLAGS="-A unused" cargo +nightly clippy --all-targets --all-features -- -Dwarnings
 
 # Generate documentation for the project
 docs:

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,0 @@
-[toolchain]
-channel = "1.85.0"

--- a/src/bgg/circuit/mod.rs
+++ b/src/bgg/circuit/mod.rs
@@ -1,11 +1,9 @@
 pub mod gate;
 pub mod utils;
-use crate::bgg::Evaluable;
-use crate::poly::Poly;
+use crate::{bgg::Evaluable, poly::Poly};
 pub use gate::{PolyGate, PolyGateType};
 use itertools::Itertools;
-use std::collections::BTreeMap;
-use std::fmt::Debug;
+use std::{collections::BTreeMap, fmt::Debug};
 pub use utils::*;
 
 #[derive(Debug, Clone)]
@@ -283,15 +281,17 @@ impl<P: Poly> PolyCircuit<P> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::poly::{
-        dcrt::{
-            params::DCRTPolyParams, poly::DCRTPoly, sampler::uniform::DCRTPolyUniformSampler,
-            FinRingElem,
+    use crate::{
+        poly::{
+            dcrt::{
+                params::DCRTPolyParams, poly::DCRTPoly, sampler::uniform::DCRTPolyUniformSampler,
+                FinRingElem,
+            },
+            sampler::DistType,
+            PolyParams,
         },
-        sampler::DistType,
-        PolyParams,
+        utils::{create_bit_random_poly, create_random_poly},
     };
-    use crate::utils::{create_bit_random_poly, create_random_poly};
 
     #[test]
     fn test_eval_add() {
@@ -631,10 +631,10 @@ mod tests {
         let poly2 = create_bit_random_poly(&params);
         let result =
             circuit.eval(&params, DCRTPoly::const_one(&params), &[poly1.clone(), poly2.clone()]);
-        let expected = (poly1.clone() + poly2.clone())
-            - (DCRTPoly::from_const(&params, &FinRingElem::new(2, params.modulus()))
-                * poly1
-                * poly2);
+        let expected = (poly1.clone() + poly2.clone()) -
+            (DCRTPoly::from_const(&params, &FinRingElem::new(2, params.modulus())) *
+                poly1 *
+                poly2);
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].coeffs(), expected.coeffs());
     }
@@ -650,11 +650,11 @@ mod tests {
         let poly2 = create_bit_random_poly(&params);
         let result =
             circuit.eval(&params, DCRTPoly::const_one(&params), &[poly1.clone(), poly2.clone()]);
-        let expected = DCRTPoly::const_one(&params)
-            - ((poly1.clone() + poly2.clone())
-                - (DCRTPoly::from_const(&params, &FinRingElem::new(2, params.modulus()))
-                    * poly1
-                    * poly2));
+        let expected = DCRTPoly::const_one(&params) -
+            ((poly1.clone() + poly2.clone()) -
+                (DCRTPoly::from_const(&params, &FinRingElem::new(2, params.modulus())) *
+                    poly1 *
+                    poly2));
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].coeffs(), expected.coeffs());
     }
@@ -708,8 +708,9 @@ mod tests {
         let inputs = circuit.input(c0_bits.len() + c1_bits.len() + 1);
         assert_eq!(inputs.len(), params.modulus_bits() * 2 + 1);
 
-        // Input: c0_bits[0], ..., c0_bits[modulus_bits - 1], c1_bits[0], ..., c1_bits[modulus_bits - 1], k
-        // Output: c0_bits[0] * k, ..., c0_bits[modulus_bits - 1] * k, c1_bits[0] * k, ..., c1_bits[modulus_bits - 1] * k
+        // Input: c0_bits[0], ..., c0_bits[modulus_bits - 1], c1_bits[0], ..., c1_bits[modulus_bits
+        // - 1], k Output: c0_bits[0] * k, ..., c0_bits[modulus_bits - 1] * k, c1_bits[0] *
+        // k, ..., c1_bits[modulus_bits - 1] * k
         let k_id = inputs[inputs.len() - 1];
         let output_ids = inputs
             .iter()

--- a/src/bgg/circuit/utils.rs
+++ b/src/bgg/circuit/utils.rs
@@ -2,7 +2,8 @@ use crate::{bgg::Evaluable, poly::Poly};
 
 use super::PolyCircuit;
 
-/// Build a circuit that takes as input a public circuit and a private input, and outputs inner products between the `num_priv_input`-sized output of the public circuit and the private input.
+/// Build a circuit that takes as input a public circuit and a private input, and outputs inner
+/// products between the `num_priv_input`-sized output of the public circuit and the private input.
 pub fn build_circuit_ip_priv_and_pub_outputs<P: Poly, E: Evaluable<P>>(
     public_circuit: PolyCircuit<P>,
     num_priv_input: usize,
@@ -37,7 +38,8 @@ pub fn build_circuit_ip_priv_and_pub_outputs<P: Poly, E: Evaluable<P>>(
     circuit
 }
 
-/// Build a circuit that takes as input `num_bits` bits and outputs the integer represented by the bits.
+/// Build a circuit that takes as input `num_bits` bits and outputs the integer represented by the
+/// bits.
 pub fn build_circuit_bits_to_int<P: Poly, E: Evaluable<P>>(
     params: &P::Params,
     num_bits: usize,
@@ -94,10 +96,13 @@ pub fn build_circuit_ip_to_int<P: Poly, E: Evaluable<P>>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::poly::dcrt::FinRingElem;
-    use crate::poly::dcrt::{params::DCRTPolyParams, poly::DCRTPoly};
-    use crate::poly::params::PolyParams;
-    use crate::utils::{create_bit_poly, create_random_poly};
+    use crate::{
+        poly::{
+            dcrt::{params::DCRTPolyParams, poly::DCRTPoly, FinRingElem},
+            params::PolyParams,
+        },
+        utils::{create_bit_poly, create_random_poly},
+    };
 
     #[test]
     fn test_build_ip_priv_and_pub_circuit_outputs() {

--- a/src/bgg/encoding.rs
+++ b/src/bgg/encoding.rs
@@ -109,13 +109,18 @@ impl<M: PolyMatrix> Evaluable<M::P> for BggEncoding<M> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::bgg::circuit::PolyCircuit;
-    use crate::bgg::sampler::{BGGEncodingSampler, BGGPublicKeySampler};
-    use crate::poly::dcrt::{
-        params::DCRTPolyParams, poly::DCRTPoly, sampler::hash::DCRTPolyHashSampler,
-        sampler::uniform::DCRTPolyUniformSampler,
+    use crate::{
+        bgg::{
+            circuit::PolyCircuit,
+            sampler::{BGGEncodingSampler, BGGPublicKeySampler},
+        },
+        poly::dcrt::{
+            params::DCRTPolyParams,
+            poly::DCRTPoly,
+            sampler::{hash::DCRTPolyHashSampler, uniform::DCRTPolyUniformSampler},
+        },
+        utils::{create_bit_random_poly, create_random_poly},
     };
-    use crate::utils::{create_bit_random_poly, create_random_poly};
     use keccak_asm::Keccak256;
     use std::sync::Arc;
 
@@ -500,8 +505,8 @@ mod tests {
     //     // c1 = -a
     //     let m = uniform_sampler.sample_poly(&params, &DistType::BitDist);
     //     let s = uniform_sampler.sample_poly(&params, &DistType::BitDist);
-    //     let e = uniform_sampler.sample_poly(&params, &DistType::GaussDist { sigma: 0.0 }); // todo: set error
-    //     let a = uniform_sampler.sample_poly(&params, &DistType::FinRingDist);
+    //     let e = uniform_sampler.sample_poly(&params, &DistType::GaussDist { sigma: 0.0 }); //
+    // todo: set error     let a = uniform_sampler.sample_poly(&params, &DistType::FinRingDist);
     //     let c0 = -a.clone();
     //     let c1 = a * s.clone() + e + m.clone();
 
@@ -513,22 +518,23 @@ mod tests {
 
     //     // plaintexts is the concatenation of 1, c0_bits, c1_bits, k
     //     let plaintexts =
-    //         [vec![DCRTPoly::const_one(&params)], c0_bits.clone(), c1_bits.clone(), vec![k.clone()]]
-    //             .concat();
+    //         [vec![DCRTPoly::const_one(&params)], c0_bits.clone(), c1_bits.clone(),
+    // vec![k.clone()]]             .concat();
 
     //     assert_eq!(plaintexts.len(), (params.modulus_bits() * 2) + 2);
 
     //     // Create encoding sampler and encodings
-    //     let bgg_encoding_sampler = BGGEncodingSampler::new(&params, &secret, uniform_sampler, 0.0);
-    //     let encodings = bgg_encoding_sampler.sample(&params, &pubkeys, &plaintexts, true);
-    //     let enc_one = encodings[0].clone();
+    //     let bgg_encoding_sampler = BGGEncodingSampler::new(&params, &secret, uniform_sampler,
+    // 0.0);     let encodings = bgg_encoding_sampler.sample(&params, &pubkeys, &plaintexts,
+    // true);     let enc_one = encodings[0].clone();
 
     //     assert_eq!(encodings.len(), plaintexts.len());
 
-    //     // Input: c0_bits[0], ..., c0_bits[modulus_bits - 1], c1_bits[0], ..., c1_bits[modulus_bits - 1], k
-    //     // Output: c0_bits[0] * k, ..., c0_bits[modulus_bits - 1] * k, c1_bits[0] * k, ..., c1_bits[modulus_bits - 1] * k
-    //     let mut circuit = PolyCircuit::<DCRTPoly>::new();
-    //     let inputs = circuit.input((params.modulus_bits() * 2) + 1);
+    //     // Input: c0_bits[0], ..., c0_bits[modulus_bits - 1], c1_bits[0], ...,
+    // c1_bits[modulus_bits - 1], k     // Output: c0_bits[0] * k, ..., c0_bits[modulus_bits -
+    // 1] * k, c1_bits[0] * k, ..., c1_bits[modulus_bits - 1] * k     let mut circuit =
+    // PolyCircuit::<DCRTPoly>::new();     let inputs = circuit.input((params.modulus_bits() *
+    // 2) + 1);
 
     //     let k_id = inputs[inputs.len() - 1];
     //     let output_ids = inputs

--- a/src/bgg/public_key.rs
+++ b/src/bgg/public_key.rs
@@ -81,12 +81,11 @@ impl<M: PolyMatrix> Evaluable<M::P> for BggPublicKey<M> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::bgg::circuit::PolyCircuit;
-    use crate::bgg::sampler::BGGPublicKeySampler;
-    use crate::poly::dcrt::{
-        params::DCRTPolyParams, poly::DCRTPoly, sampler::hash::DCRTPolyHashSampler,
+    use crate::{
+        bgg::{circuit::PolyCircuit, sampler::BGGPublicKeySampler},
+        poly::dcrt::{params::DCRTPolyParams, poly::DCRTPoly, sampler::hash::DCRTPolyHashSampler},
+        utils::create_random_poly,
     };
-    use crate::utils::create_random_poly;
     use keccak_asm::Keccak256;
     use std::sync::Arc;
 

--- a/src/bgg/sampler.rs
+++ b/src/bgg/sampler.rs
@@ -1,9 +1,13 @@
 use super::{BggEncoding, BggPublicKey};
-use crate::parallel_iter;
-use crate::poly::polynomial::Poly;
-use crate::poly::sampler::{DistType, PolyUniformSampler};
-use crate::poly::PolyMatrix;
-use crate::poly::{params::PolyParams, sampler::PolyHashSampler};
+use crate::{
+    parallel_iter,
+    poly::{
+        params::PolyParams,
+        polynomial::Poly,
+        sampler::{DistType, PolyHashSampler, PolyUniformSampler},
+        PolyMatrix,
+    },
+};
 use itertools::Itertools;
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
@@ -33,7 +37,8 @@ where
     /// Sample a public key matrix
     /// # Arguments
     /// * `tag`: The tag to sample the public key matrix
-    /// * `reveal_plaintexts`: A vector of booleans indicating whether the plaintexts associated to the public keys should be revealed
+    /// * `reveal_plaintexts`: A vector of booleans indicating whether the plaintexts associated to
+    ///   the public keys should be revealed
     /// # Returns
     /// A vector of public key matrices
     pub fn sample(
@@ -155,8 +160,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::bgg::eval::Evaluable;
     use crate::{
+        bgg::eval::Evaluable,
         poly::dcrt::{
             DCRTPoly, DCRTPolyHashSampler, DCRTPolyMatrix, DCRTPolyParams, DCRTPolyUniformSampler,
         },
@@ -248,15 +253,15 @@ mod tests {
         assert_eq!(bgg_encodings.len(), packed_input_size + 1);
         assert_eq!(
             bgg_encodings[0].vector,
-            bgg_sampler.secret_vec.clone() * bgg_encodings[0].pubkey.matrix.clone()
-                - bgg_sampler.secret_vec.clone()
-                    * (g.clone() * bgg_encodings[0].plaintext.clone().unwrap())
+            bgg_sampler.secret_vec.clone() * bgg_encodings[0].pubkey.matrix.clone() -
+                bgg_sampler.secret_vec.clone() *
+                    (g.clone() * bgg_encodings[0].plaintext.clone().unwrap())
         );
         assert_eq!(
             bgg_encodings[1].vector,
-            bgg_sampler.secret_vec.clone() * bgg_encodings[1].pubkey.matrix.clone()
-                - bgg_sampler.secret_vec.clone()
-                    * (g * bgg_encodings[1].plaintext.clone().unwrap())
+            bgg_sampler.secret_vec.clone() * bgg_encodings[1].pubkey.matrix.clone() -
+                bgg_sampler.secret_vec.clone() *
+                    (g * bgg_encodings[1].plaintext.clone().unwrap())
         )
     }
 
@@ -290,8 +295,8 @@ mod tests {
                 assert_eq!(addition.vector, a.clone().vector + b.clone().vector);
                 assert_eq!(
                     addition.vector,
-                    bgg_sampler.secret_vec.clone()
-                        * (addition.pubkey.matrix - (g * addition.plaintext.unwrap()))
+                    bgg_sampler.secret_vec.clone() *
+                        (addition.pubkey.matrix - (g * addition.plaintext.unwrap()))
                 )
             }
         }
@@ -326,8 +331,8 @@ mod tests {
                 let g = DCRTPolyMatrix::gadget_matrix(&params, 2);
                 assert_eq!(
                     multiplication.vector,
-                    (bgg_sampler.secret_vec.clone()
-                        * (multiplication.pubkey.matrix - (g * multiplication.plaintext.unwrap())))
+                    (bgg_sampler.secret_vec.clone() *
+                        (multiplication.pubkey.matrix - (g * multiplication.plaintext.unwrap())))
                 )
             }
         }
@@ -379,9 +384,9 @@ mod tests {
             // Alternative verification: check that the vector satisfies the BGG encoding relation
             assert_eq!(
                 scalar_mul.vector,
-                bgg_sampler.secret_vec.clone()
-                    * (scalar_mul.pubkey.matrix.clone()
-                        - (g * scalar_mul.plaintext.as_ref().unwrap().clone()))
+                bgg_sampler.secret_vec.clone() *
+                    (scalar_mul.pubkey.matrix.clone() -
+                        (g * scalar_mul.plaintext.as_ref().unwrap().clone()))
             );
         }
     }

--- a/src/io/eval.rs
+++ b/src/io/eval.rs
@@ -1,8 +1,8 @@
-use super::utils::*;
-use super::{Obfuscation, ObfuscationParams};
-use crate::bgg::sampler::BGGPublicKeySampler;
-use crate::bgg::BggEncoding;
-use crate::poly::{matrix::*, sampler::*, Poly, PolyElem, PolyParams};
+use super::{utils::*, Obfuscation, ObfuscationParams};
+use crate::{
+    bgg::{sampler::BGGPublicKeySampler, BggEncoding},
+    poly::{matrix::*, sampler::*, Poly, PolyElem, PolyParams},
+};
 use itertools::Itertools;
 use std::sync::Arc;
 
@@ -53,9 +53,9 @@ where
                 let gadget_2 = M::gadget_matrix(&params, 2);
                 M::from_poly_vec_row(params.as_ref(), polys).tensor(&gadget_2)
             };
-            let expected_encoding_init = self.s_init.clone()
-                * (public_data.pubkeys[0][0].concat_matrix(&public_data.pubkeys[0][1..])
-                    - inserted_poly_gadget);
+            let expected_encoding_init = self.s_init.clone() *
+                (public_data.pubkeys[0][0].concat_matrix(&public_data.pubkeys[0][1..]) -
+                    inserted_poly_gadget);
             debug_assert_eq!(
                 encodings[0][0].concat_vector(&encodings[0][1..]),
                 expected_encoding_init
@@ -222,27 +222,27 @@ where
                 .collect::<Vec<_>>();
             debug_assert_eq!(output_plaintext, hardcoded_key_bits);
             {
-                let expcted = last_s.clone()
-                    * (output_encodings[0].pubkey.matrix.clone()
-                        - M::gadget_matrix(&params, 2)
-                            * output_encodings[0].plaintext.clone().unwrap());
+                let expcted = last_s.clone() *
+                    (output_encodings[0].pubkey.matrix.clone() -
+                        M::gadget_matrix(&params, 2) *
+                            output_encodings[0].plaintext.clone().unwrap());
                 debug_assert_eq!(output_encodings[0].vector, expcted);
             }
 
             // let a_f = obfuscation.final_preimage_target.slice_rows(0, 2).clone();
-            // debug_assert_eq!(output_encodings[0].pubkey.matrix.clone() * unit_vector.decompose(), a_f);
-            // let expected_final_v = last_s.clone() * &a_f;
+            // debug_assert_eq!(output_encodings[0].pubkey.matrix.clone() * unit_vector.decompose(),
+            // a_f); let expected_final_v = last_s.clone() * &a_f;
             // debug_assert_eq!(final_v, expected_final_v);
 
             // let expected_output_encodings_vec = last_s.clone() * &a_f
-            //     + M::from_poly_vec_row(
-            //         &params,
-            //         vec![output_encodings[0].plaintext.as_ref().unwrap().clone()],
+            //     + M::from_poly_vec_row( &params,
+            //       vec![output_encodings[0].plaintext.as_ref().unwrap().clone()],
             //     );
             // debug_assert_eq!(output_encodings_vec, expected_output_encodings_vec);
 
-            // let scale = M::P::from_const(&params, &<M::P as Poly>::Elem::half_q(&params.modulus()));
-            // debug_assert_eq!(z, obfuscation.hardcoded_key * scale);
+            // let scale = M::P::from_const(&params, &<M::P as
+            // Poly>::Elem::half_q(&params.modulus())); debug_assert_eq!(z,
+            // obfuscation.hardcoded_key * scale);
         }
         z.get_row(0).into_iter().flat_map(|p| p.extract_highest_bits()).collect_vec()
     }

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -2,9 +2,10 @@ pub mod eval;
 pub mod obf;
 pub mod utils;
 
-use crate::bgg::circuit::PolyCircuit;
-use crate::bgg::BggEncoding;
-use crate::poly::{Poly, PolyMatrix, PolyParams};
+use crate::{
+    bgg::{circuit::PolyCircuit, BggEncoding},
+    poly::{Poly, PolyMatrix, PolyParams},
+};
 
 #[derive(Debug, Clone)]
 pub struct Obfuscation<M: PolyMatrix> {

--- a/src/io/obf.rs
+++ b/src/io/obf.rs
@@ -160,8 +160,8 @@ where
                 M::from_poly_vec_row(params.as_ref(), polys).tensor(&gadget_2)
             };
             let bottom = public_data.pubkeys[idx + 1][0]
-                .concat_matrix(&public_data.pubkeys[idx + 1][1..])
-                - &inserted_poly_gadget;
+                .concat_matrix(&public_data.pubkeys[idx + 1][1..]) -
+                &inserted_poly_gadget;
             let k_target = top.concat_rows(&[bottom]);
             let b_matrix = if bit == 0 { b_next_0 } else { b_next_1 };
             let trapdoor = if bit == 0 { b_next_0_trapdoor } else { b_next_1_trapdoor };

--- a/src/io/utils.rs
+++ b/src/io/utils.rs
@@ -1,7 +1,12 @@
 use super::ObfuscationParams;
-use crate::bgg::circuit::{build_circuit_ip_to_int, PolyCircuit};
-use crate::bgg::{sampler::*, BggPublicKey, Evaluable};
-use crate::poly::{matrix::*, sampler::*, Poly, PolyParams};
+use crate::{
+    bgg::{
+        circuit::{build_circuit_ip_to_int, PolyCircuit},
+        sampler::*,
+        BggPublicKey, Evaluable,
+    },
+    poly::{matrix::*, sampler::*, Poly, PolyParams},
+};
 use itertools::Itertools;
 use std::marker::PhantomData;
 
@@ -151,15 +156,21 @@ pub fn build_final_step_circuit<P: Poly, E: Evaluable<P>>(
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::bgg::sampler::{BGGEncodingSampler, BGGPublicKeySampler};
-    use crate::bgg::BggEncoding;
-    use crate::poly::dcrt::{
-        DCRTPoly, DCRTPolyHashSampler, DCRTPolyMatrix, DCRTPolyParams, DCRTPolyUniformSampler,
-        FinRingElem,
+    use crate::{
+        bgg::{
+            sampler::{BGGEncodingSampler, BGGPublicKeySampler},
+            BggEncoding,
+        },
+        poly::{
+            dcrt::{
+                DCRTPoly, DCRTPolyHashSampler, DCRTPolyMatrix, DCRTPolyParams,
+                DCRTPolyUniformSampler, FinRingElem,
+            },
+            element::PolyElem,
+            sampler::DistType,
+        },
+        utils::create_bit_random_poly,
     };
-    use crate::poly::element::PolyElem;
-    use crate::poly::sampler::DistType;
-    use crate::utils::create_bit_random_poly;
     use keccak_asm::Keccak256;
     use num_bigint::BigUint;
     use std::sync::Arc;
@@ -348,9 +359,9 @@ mod test {
                 &params,
                 vec![outputs_encodings[0].plaintext.clone().unwrap()],
             );
-            bgg_encoding_sampler.secret_vec
-                * (outputs_encodings[0].pubkey.matrix.clone()
-                    - plaintext.tensor(&DCRTPolyMatrix::gadget_matrix(&params, 2)))
+            bgg_encoding_sampler.secret_vec *
+                (outputs_encodings[0].pubkey.matrix.clone() -
+                    plaintext.tensor(&DCRTPolyMatrix::gadget_matrix(&params, 2)))
         };
         assert_eq!(outputs_encodings[0].vector, expected_vector);
     }

--- a/src/poly/dcrt/sampler/hash.rs
+++ b/src/poly/dcrt/sampler/hash.rs
@@ -85,8 +85,9 @@ where
 
         let ring_elems = match dist {
             DistType::FinRingDist => {
-                // index = number of hashes to be performed = ceil(nrow * ncol * n * ceil(log2(q)) / hash_output_size)
-                // field_elements = number of field elements sampled = (bits / ceil(log2(q)))
+                // index = number of hashes to be performed = ceil(nrow * ncol * n * ceil(log2(q)) /
+                // hash_output_size) field_elements = number of field elements
+                // sampled = (bits / ceil(log2(q)))
                 let bit_length = params.modulus_bits();
                 let index = (nrow * ncol * n * bit_length).div_ceil(hash_output_size);
                 // bits = number of resulting bits from hashing ops = hash_output_size * index
@@ -132,8 +133,9 @@ where
                 ring_elems
             }
             DistType::BitDist => {
-                // index = number of hashes to be performed = ceil(nrow * ncol * n * ceil(log2(q)) / hash_output_size)
-                // field_elements = number of field elements sampled = (bits / ceil(log2(q)))
+                // index = number of hashes to be performed = ceil(nrow * ncol * n * ceil(log2(q)) /
+                // hash_output_size) field_elements = number of field elements
+                // sampled = (bits / ceil(log2(q)))
                 let index = (nrow * ncol * n).div_ceil(hash_output_size);
                 let mut ring_elems = Vec::with_capacity(hash_output_size * index);
                 for i in 0..index {

--- a/src/poly/dcrt/sampler/trapdoor.rs
+++ b/src/poly/dcrt/sampler/trapdoor.rs
@@ -128,7 +128,8 @@ impl PolyTrapdoorSampler for DCRTPolyTrapdoorSampler {
                 .map(|block| {
                     let start_col = block * size;
 
-                    // Calculate end_col based on whether this is the last block with remaining columns
+                    // Calculate end_col based on whether this is the last block with remaining
+                    // columns
                     let end_col = if block == full_blocks && remaining_cols > 0 {
                         start_col + remaining_cols
                     } else {


### PR DESCRIPTION
- most of `rust fmt` features are only allowed on nightly. 
- TIL: `OpenFHE` installation have 3 step 
1. `cmake ..` : this will create `/build` folder
2. `make`
3. `sudo make install` : this installs in `"/usr/local"` ( including `local` and `included`).

it's tricky to cache"/usr/local/"` all on action (too large post cache took like 5m) 
so tempt to cache up to 2) step and do 3) which that's the what majority of time consumed anyway& slower than start from 1)

so looked up if there's any example that cache `OpenFHE` C++ binary somehow but e.g `openfhe-rs` just rebuild everytime, which I concluded for now it's works in this way. 

- so instead of caching fhe, at least this pr cache rust artifacts

resolving #15 