### PR TITLE
Perf: `bitvec!` hash sample

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,8 @@ itertools = "0.14.0"
 # for now we put in test
 tracing = "0.1"
 tracing-subscriber = "0.3"
+bitvec = "1"
+memory-stats = "1.2.0"
 
 [dev-dependencies]
 keccak-asm = { version = "0.1.4" }

--- a/src/poly/dcrt/sampler/hash.rs
+++ b/src/poly/dcrt/sampler/hash.rs
@@ -94,7 +94,7 @@ where
                 let bit_length = params.modulus_bits();
                 let index = (nrow * ncol * n * bit_length).div_ceil(hash_output_size);
                 // bits = number of resulting bits from hashing ops = hash_output_size * index
-                let mut bv = bitvec![u8, Msb0;];
+                let mut bv = bitvec![u8, Lsb0;];
                 let mut og_hasher: H = H::new();
                 og_hasher.update(self.key);
                 og_hasher.update(tag.as_ref());
@@ -102,9 +102,9 @@ where
                 for i in 0..index {
                     let mut hasher = og_hasher.clone();
                     //  H ( key || tag || i )
-                    hasher.update(i.to_be_bytes());
+                    hasher.update(i.to_le_bytes());
                     for &byte in hasher.finalize().iter() {
-                        for bit_index in (0..8).rev() {
+                        for bit_index in 0..8 {
                             bv.push((byte >> bit_index) & 1 != 0);
                         }
                     }

--- a/src/poly/dcrt/sampler/hash.rs
+++ b/src/poly/dcrt/sampler/hash.rs
@@ -1,12 +1,18 @@
-use std::marker::PhantomData;
-
-use crate::poly::{
-    dcrt::{DCRTPoly, DCRTPolyMatrix, DCRTPolyParams, FinRingElem},
-    sampler::{DistType, PolyHashSampler},
-    Poly, PolyMatrix, PolyParams,
+use crate::{
+    parallel_iter,
+    poly::{
+        dcrt::{DCRTPoly, DCRTPolyMatrix, DCRTPolyParams, FinRingElem},
+        sampler::{DistType, PolyHashSampler},
+        Poly, PolyMatrix, PolyParams,
+    },
 };
+use bitvec::prelude::*;
 use digest::OutputSizeUser;
 use num_bigint::BigUint;
+#[cfg(feature = "parallel")]
+use rayon::prelude::*;
+use std::marker::PhantomData;
+use tracing::info;
 
 pub struct DCRTPolyHashSampler<H: OutputSizeUser + digest::Digest> {
     key: [u8; 32],
@@ -43,31 +49,28 @@ where
 
         // From field elements to nrow * ncol polynomials
         let total_poly = nrow * ncol;
-        let mut offset = 0;
-        let mut all_polys = Vec::with_capacity(total_poly);
-        for _ in 0..total_poly {
-            let coeffs = &ring_elems[offset..offset + n];
-            offset += n;
-            let poly = DCRTPoly::from_coeffs(params, coeffs);
-            all_polys.push(poly);
-        }
-
-        // From polynomials to matrix such that the first row of the matrixcontains the first ncol
-        // polynomials
-        let mut matrix_inner = Vec::with_capacity(nrow);
-        let mut poly_iter = all_polys.into_iter();
-        for _ in 0..nrow {
-            let row_polys: Vec<DCRTPoly> = poly_iter.by_ref().take(ncol).collect();
-            matrix_inner.push(row_polys);
-        }
-
-        DCRTPolyMatrix::from_poly_vec(params, matrix_inner)
+        info!("total_poly {} {} {}", total_poly, ncol, nrow);
+        DCRTPolyMatrix::from_poly_vec(
+            params,
+            parallel_iter!(0..nrow)
+                .map(|row_idx| {
+                    let row_offset = row_idx * ncol * n;
+                    parallel_iter!(0..ncol)
+                        .map(|col_idx| {
+                            let offset = row_offset + col_idx * n;
+                            let coeffs = &ring_elems[offset..offset + n];
+                            DCRTPoly::from_coeffs(params, coeffs)
+                        })
+                        .collect()
+                })
+                .collect(),
+        )
     }
 }
 
 impl<H> PolyHashSampler<[u8; 32]> for DCRTPolyHashSampler<H>
 where
-    H: OutputSizeUser + digest::Digest,
+    H: OutputSizeUser + digest::Digest + Clone,
 {
     type M = DCRTPolyMatrix;
 
@@ -91,45 +94,41 @@ where
                 let bit_length = params.modulus_bits();
                 let index = (nrow * ncol * n * bit_length).div_ceil(hash_output_size);
                 // bits = number of resulting bits from hashing ops = hash_output_size * index
-                let mut bits = Vec::with_capacity(hash_output_size * index);
-                let mut ring_elems = Vec::with_capacity((index * hash_output_size) / bit_length);
-                for i in 0..(index) {
+                let mut bv = bitvec![u8, Msb0;];
+                let mut og_hasher: H = H::new();
+                og_hasher.update(&self.key);
+                og_hasher.update(tag.as_ref());
+                info!("before loop {}, {}", index, bit_length);
+                for i in 0..index {
+                    let mut hasher = og_hasher.clone();
                     //  H ( key || tag || i )
-                    let mut hasher = H::new();
-                    // todo: we currently assuming index is less than u32
-                    let min_i_type = std::mem::size_of_val(&i);
-                    if min_i_type > std::mem::size_of::<u8>() {
-                        let mut combined =
-                            Vec::with_capacity(self.key.len() + tag.as_ref().len() + 32);
-                        combined.extend_from_slice(&self.key);
-                        combined.extend_from_slice(tag.as_ref());
-                        combined.extend_from_slice(&i.to_be_bytes());
-                        hasher.update(&combined);
-                    } else {
-                        let mut combined =
-                            Vec::with_capacity(self.key.len() + tag.as_ref().len() + 1);
-                        combined.extend_from_slice(&self.key);
-                        combined.extend_from_slice(tag.as_ref());
-                        combined.push(i as u8);
-                        hasher.update(&combined);
-                    }
-
+                    hasher.update(&i.to_be_bytes());
                     for &byte in hasher.finalize().iter() {
-                        for bit_index in 0..8 {
-                            let bit = (byte >> bit_index) & 1;
-                            bits.push(bit);
+                        for bit_index in (0..8).rev() {
+                            bv.push((byte >> bit_index) & 1 != 0);
                         }
                     }
                 }
-                // From bits to field elements
-                let mut offset = 0;
-                for _ in 0..(bits.len() / bit_length) {
-                    let value_bits = &bits[offset..offset + bit_length];
-                    let value = BigUint::from_radix_be(value_bits, 2).unwrap();
-                    offset += bit_length;
-                    let fe = FinRingElem::new(value, q.clone());
-                    ring_elems.push(fe);
-                }
+                info!(?bit_length, "finished hasher, bv length {}", bv.len());
+                let num_chunks = bv.len() / bit_length;
+                let ring_elems: Vec<FinRingElem> = parallel_iter!(0..num_chunks)
+                    .map(|i| {
+                        let start = i * bit_length;
+                        let end = start + bit_length;
+                        let value_bits = &bv[start..end];
+
+                        let mut value = BigUint::default();
+                        for bit in value_bits.iter() {
+                            value <<= 1;
+                            if *bit {
+                                value |= BigUint::from(1u32);
+                            }
+                        }
+                        FinRingElem::new(value, q.clone())
+                    })
+                    .collect();
+                info!("finished ring_elems");
+                debug_assert_eq!(ring_elems.len(), (index * hash_output_size) / bit_length);
                 ring_elems
             }
             DistType::BitDist => {

--- a/src/poly/dcrt/sampler/hash.rs
+++ b/src/poly/dcrt/sampler/hash.rs
@@ -96,13 +96,13 @@ where
                 // bits = number of resulting bits from hashing ops = hash_output_size * index
                 let mut bv = bitvec![u8, Msb0;];
                 let mut og_hasher: H = H::new();
-                og_hasher.update(&self.key);
+                og_hasher.update(self.key);
                 og_hasher.update(tag.as_ref());
                 info!("before loop {}, {}", index, bit_length);
                 for i in 0..index {
                     let mut hasher = og_hasher.clone();
                     //  H ( key || tag || i )
-                    hasher.update(&i.to_be_bytes());
+                    hasher.update(i.to_be_bytes());
                     for &byte in hasher.finalize().iter() {
                         for bit_index in (0..8).rev() {
                             bv.push((byte >> bit_index) & 1 != 0);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -3,8 +3,10 @@ use crate::poly::{
     sampler::DistType,
     Poly,
 };
+use memory_stats::memory_stats;
 use num_bigint::BigUint;
 use num_traits::{One, Zero};
+use tracing::info;
 
 pub fn ceil_log2(q: &BigUint) -> usize {
     assert!(!q.is_zero(), "log2 is undefined for zero");
@@ -67,6 +69,17 @@ pub fn create_bit_poly(params: &DCRTPolyParams, bit: bool) -> DCRTPoly {
         DCRTPoly::const_one(params)
     } else {
         DCRTPoly::const_zero(params)
+    }
+}
+
+pub fn log_mem() {
+    if let Some(usage) = memory_stats() {
+        info!(
+            "Current physical/virtural memory usage: {} / {}",
+            usage.physical_mem, usage.virtual_mem
+        );
+    } else {
+        info!("Couldn't get the current memory usage :(");
     }
 }
 


### PR DESCRIPTION
optimize hash sampler `sample` step by using `bitvec` representation instead of naive `Vec<u8>` ( aproximate: 8x memory efficient)