### PR TITLE
Optimization `mul_tensor_identity_decompose`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ num-traits = "0.2"
 rayon = { version = "1.5", optional = true }
 rand = { version = "0.9.0", features = ["std_rng"] }
 itertools = "0.14.0"
-# for now we put in test
 tracing = "0.1"
 tracing-subscriber = "0.3"
 bitvec = "1"

--- a/src/bgg/sampler.rs
+++ b/src/bgg/sampler.rs
@@ -51,7 +51,6 @@ where
         let log_q = params.modulus_bits();
         let columns = 2 * log_q;
         let packed_input_size = 1 + reveal_plaintexts.len(); // first slot is allocated to the constant 1 polynomial plaintext
-        info!("before all_matrix");
         let all_matrix = self.sampler.sample_hash(
             params,
             tag,
@@ -59,7 +58,6 @@ where
             columns * packed_input_size,
             DistType::FinRingDist,
         );
-        info!("all_matrix");
 
         parallel_iter!(0..packed_input_size)
             .map(|idx| {
@@ -254,15 +252,15 @@ mod tests {
         assert_eq!(bgg_encodings.len(), packed_input_size + 1);
         assert_eq!(
             bgg_encodings[0].vector,
-            bgg_sampler.secret_vec.clone() * bgg_encodings[0].pubkey.matrix.clone() -
-                bgg_sampler.secret_vec.clone() *
-                    (g.clone() * bgg_encodings[0].plaintext.clone().unwrap())
+            bgg_sampler.secret_vec.clone() * bgg_encodings[0].pubkey.matrix.clone()
+                - bgg_sampler.secret_vec.clone()
+                    * (g.clone() * bgg_encodings[0].plaintext.clone().unwrap())
         );
         assert_eq!(
             bgg_encodings[1].vector,
-            bgg_sampler.secret_vec.clone() * bgg_encodings[1].pubkey.matrix.clone() -
-                bgg_sampler.secret_vec.clone() *
-                    (g * bgg_encodings[1].plaintext.clone().unwrap())
+            bgg_sampler.secret_vec.clone() * bgg_encodings[1].pubkey.matrix.clone()
+                - bgg_sampler.secret_vec.clone()
+                    * (g * bgg_encodings[1].plaintext.clone().unwrap())
         )
     }
 
@@ -296,8 +294,8 @@ mod tests {
                 assert_eq!(addition.vector, a.clone().vector + b.clone().vector);
                 assert_eq!(
                     addition.vector,
-                    bgg_sampler.secret_vec.clone() *
-                        (addition.pubkey.matrix - (g * addition.plaintext.unwrap()))
+                    bgg_sampler.secret_vec.clone()
+                        * (addition.pubkey.matrix - (g * addition.plaintext.unwrap()))
                 )
             }
         }
@@ -332,8 +330,8 @@ mod tests {
                 let g = DCRTPolyMatrix::gadget_matrix(&params, 2);
                 assert_eq!(
                     multiplication.vector,
-                    (bgg_sampler.secret_vec.clone() *
-                        (multiplication.pubkey.matrix - (g * multiplication.plaintext.unwrap())))
+                    (bgg_sampler.secret_vec.clone()
+                        * (multiplication.pubkey.matrix - (g * multiplication.plaintext.unwrap())))
                 )
             }
         }
@@ -385,9 +383,9 @@ mod tests {
             // Alternative verification: check that the vector satisfies the BGG encoding relation
             assert_eq!(
                 scalar_mul.vector,
-                bgg_sampler.secret_vec.clone() *
-                    (scalar_mul.pubkey.matrix.clone() -
-                        (g * scalar_mul.plaintext.as_ref().unwrap().clone()))
+                bgg_sampler.secret_vec.clone()
+                    * (scalar_mul.pubkey.matrix.clone()
+                        - (g * scalar_mul.plaintext.as_ref().unwrap().clone()))
             );
         }
     }

--- a/src/bgg/sampler.rs
+++ b/src/bgg/sampler.rs
@@ -130,7 +130,6 @@ where
             columns,
             DistType::GaussDist { sigma: self.gauss_sigma },
         );
-
         let all_public_key_matrix: S::M = public_keys[0]
             .matrix
             .concat_columns(&public_keys[1..].iter().map(|pk| &pk.matrix).collect_vec());
@@ -139,7 +138,6 @@ where
         let gadget = S::M::gadget_matrix(params, 2);
         let encoded_polys_vec = S::M::from_poly_vec_row(params, plaintexts.to_vec());
         let second_term = encoded_polys_vec.tensor(&(secret_vec.clone() * gadget));
-
         let all_vector = first_term - second_term + error;
 
         parallel_iter!(plaintexts)

--- a/src/bgg/sampler.rs
+++ b/src/bgg/sampler.rs
@@ -12,7 +12,6 @@ use itertools::Itertools;
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 use std::{marker::PhantomData, sync::Arc};
-use tracing::info;
 
 /// A sampler of a public key A in the BGG+ RLWE encoding scheme
 #[derive(Clone)]
@@ -252,15 +251,15 @@ mod tests {
         assert_eq!(bgg_encodings.len(), packed_input_size + 1);
         assert_eq!(
             bgg_encodings[0].vector,
-            bgg_sampler.secret_vec.clone() * bgg_encodings[0].pubkey.matrix.clone()
-                - bgg_sampler.secret_vec.clone()
-                    * (g.clone() * bgg_encodings[0].plaintext.clone().unwrap())
+            bgg_sampler.secret_vec.clone() * bgg_encodings[0].pubkey.matrix.clone() -
+                bgg_sampler.secret_vec.clone() *
+                    (g.clone() * bgg_encodings[0].plaintext.clone().unwrap())
         );
         assert_eq!(
             bgg_encodings[1].vector,
-            bgg_sampler.secret_vec.clone() * bgg_encodings[1].pubkey.matrix.clone()
-                - bgg_sampler.secret_vec.clone()
-                    * (g * bgg_encodings[1].plaintext.clone().unwrap())
+            bgg_sampler.secret_vec.clone() * bgg_encodings[1].pubkey.matrix.clone() -
+                bgg_sampler.secret_vec.clone() *
+                    (g * bgg_encodings[1].plaintext.clone().unwrap())
         )
     }
 
@@ -294,8 +293,8 @@ mod tests {
                 assert_eq!(addition.vector, a.clone().vector + b.clone().vector);
                 assert_eq!(
                     addition.vector,
-                    bgg_sampler.secret_vec.clone()
-                        * (addition.pubkey.matrix - (g * addition.plaintext.unwrap()))
+                    bgg_sampler.secret_vec.clone() *
+                        (addition.pubkey.matrix - (g * addition.plaintext.unwrap()))
                 )
             }
         }
@@ -330,8 +329,8 @@ mod tests {
                 let g = DCRTPolyMatrix::gadget_matrix(&params, 2);
                 assert_eq!(
                     multiplication.vector,
-                    (bgg_sampler.secret_vec.clone()
-                        * (multiplication.pubkey.matrix - (g * multiplication.plaintext.unwrap())))
+                    (bgg_sampler.secret_vec.clone() *
+                        (multiplication.pubkey.matrix - (g * multiplication.plaintext.unwrap())))
                 )
             }
         }
@@ -383,9 +382,9 @@ mod tests {
             // Alternative verification: check that the vector satisfies the BGG encoding relation
             assert_eq!(
                 scalar_mul.vector,
-                bgg_sampler.secret_vec.clone()
-                    * (scalar_mul.pubkey.matrix.clone()
-                        - (g * scalar_mul.plaintext.as_ref().unwrap().clone()))
+                bgg_sampler.secret_vec.clone() *
+                    (scalar_mul.pubkey.matrix.clone() -
+                        (g * scalar_mul.plaintext.as_ref().unwrap().clone()))
             );
         }
     }

--- a/src/io/eval.rs
+++ b/src/io/eval.rs
@@ -50,9 +50,9 @@ where
                 let gadget_2 = M::gadget_matrix(&params, 2);
                 M::from_poly_vec_row(params.as_ref(), polys).tensor(&gadget_2)
             };
-            let expected_encoding_init = &self.s_init *
-                &(public_data.pubkeys[0][0].concat_matrix(&public_data.pubkeys[0][1..]) -
-                    inserted_poly_gadget);
+            let expected_encoding_init = &self.s_init
+                * &(public_data.pubkeys[0][0].concat_matrix(&public_data.pubkeys[0][1..])
+                    - inserted_poly_gadget);
             debug_assert_eq!(
                 encodings[0][0].concat_vector(&encodings[0][1..]),
                 expected_encoding_init
@@ -79,11 +79,7 @@ where
             //     2 * log_q * (packed_input_size + 3),
             // );
             let new_encode_vec = {
-                let t = if *input {
-                    &public_data.rgs_decomposed[1]
-                } else {
-                    &public_data.rgs_decomposed[0]
-                };
+                let t = if *input { &public_data.rgs[1] } else { &public_data.rgs[0] };
                 let encode_vec = encodings[idx][0].concat_vector(&encodings[idx][1..]);
                 let packed_input_size = obf_params.input_size.div_ceil(dim) + 1;
                 encode_vec.mul_tensor_identity_decompose(t, packed_input_size + 1) + v
@@ -213,10 +209,10 @@ where
                 .collect::<Vec<_>>();
             debug_assert_eq!(output_plaintext, hardcoded_key_bits);
             {
-                let expcted = last_s *
-                    (output_encodings[0].pubkey.matrix.clone() -
-                        M::gadget_matrix(&params, 2) *
-                            output_encodings[0].plaintext.clone().unwrap());
+                let expcted = last_s
+                    * (output_encodings[0].pubkey.matrix.clone()
+                        - M::gadget_matrix(&params, 2)
+                            * output_encodings[0].plaintext.clone().unwrap());
                 debug_assert_eq!(output_encodings[0].vector, expcted);
             }
 

--- a/src/io/eval.rs
+++ b/src/io/eval.rs
@@ -52,9 +52,9 @@ where
                 let gadget_2 = M::gadget_matrix(&params, 2);
                 M::from_poly_vec_row(params.as_ref(), polys).tensor(&gadget_2)
             };
-            let expected_encoding_init = &self.s_init *
-                &(public_data.pubkeys[0][0].concat_matrix(&public_data.pubkeys[0][1..]) -
-                    inserted_poly_gadget);
+            let expected_encoding_init = &self.s_init
+                * &(public_data.pubkeys[0][0].concat_matrix(&public_data.pubkeys[0][1..])
+                    - inserted_poly_gadget);
             debug_assert_eq!(
                 encodings[0][0].concat_vector(&encodings[0][1..]),
                 expected_encoding_init
@@ -84,11 +84,8 @@ where
                 let t = if *input { &public_data.rgs[1] } else { &public_data.rgs[0] };
                 let encode_vec = encodings[idx][0].concat_vector(&encodings[idx][1..]);
                 let packed_input_size = obf_params.input_size.div_ceil(dim) + 1;
-                info!("🍕");
-                log_mem();
                 encode_vec.mul_tensor_identity_decompose(t, packed_input_size + 1) + v
             };
-            log_mem();
             let mut new_encodings = vec![];
             // let zero_poly = <M::P as Poly>::const_zero(&params);
             // let one_poly = <M::P as Poly>::const_one(&params);
@@ -214,10 +211,10 @@ where
                 .collect::<Vec<_>>();
             debug_assert_eq!(output_plaintext, hardcoded_key_bits);
             {
-                let expcted = last_s *
-                    (output_encodings[0].pubkey.matrix.clone() -
-                        M::gadget_matrix(&params, 2) *
-                            output_encodings[0].plaintext.clone().unwrap());
+                let expcted = last_s
+                    * (output_encodings[0].pubkey.matrix.clone()
+                        - M::gadget_matrix(&params, 2)
+                            * output_encodings[0].plaintext.clone().unwrap());
                 debug_assert_eq!(output_encodings[0].vector, expcted);
             }
 

--- a/src/io/eval.rs
+++ b/src/io/eval.rs
@@ -2,11 +2,9 @@ use super::{utils::*, Obfuscation, ObfuscationParams};
 use crate::{
     bgg::{sampler::BGGPublicKeySampler, BggEncoding},
     poly::{matrix::*, sampler::*, Poly, PolyElem, PolyParams},
-    utils::log_mem,
 };
 use itertools::Itertools;
 use std::{ops::Mul, sync::Arc};
-use tracing::info;
 
 impl<M> Obfuscation<M>
 where
@@ -52,9 +50,9 @@ where
                 let gadget_2 = M::gadget_matrix(&params, 2);
                 M::from_poly_vec_row(params.as_ref(), polys).tensor(&gadget_2)
             };
-            let expected_encoding_init = &self.s_init
-                * &(public_data.pubkeys[0][0].concat_matrix(&public_data.pubkeys[0][1..])
-                    - inserted_poly_gadget);
+            let expected_encoding_init = &self.s_init *
+                &(public_data.pubkeys[0][0].concat_matrix(&public_data.pubkeys[0][1..]) -
+                    inserted_poly_gadget);
             debug_assert_eq!(
                 encodings[0][0].concat_vector(&encodings[0][1..]),
                 expected_encoding_init
@@ -211,10 +209,10 @@ where
                 .collect::<Vec<_>>();
             debug_assert_eq!(output_plaintext, hardcoded_key_bits);
             {
-                let expcted = last_s
-                    * (output_encodings[0].pubkey.matrix.clone()
-                        - M::gadget_matrix(&params, 2)
-                            * output_encodings[0].plaintext.clone().unwrap());
+                let expcted = last_s *
+                    (output_encodings[0].pubkey.matrix.clone() -
+                        M::gadget_matrix(&params, 2) *
+                            output_encodings[0].plaintext.clone().unwrap());
                 debug_assert_eq!(output_encodings[0].vector, expcted);
             }
 

--- a/src/io/eval.rs
+++ b/src/io/eval.rs
@@ -86,7 +86,7 @@ where
                 };
                 let encode_vec = encodings[idx][0].concat_vector(&encodings[idx][1..]);
                 let packed_input_size = obf_params.input_size.div_ceil(dim) + 1;
-                encode_vec.mul_tensor_identity(t, packed_input_size + 1) + v
+                encode_vec.mul_tensor_identity_decompose(t, packed_input_size + 1) + v
             };
             let mut new_encodings = vec![];
             // let zero_poly = <M::P as Poly>::const_zero(&params);

--- a/src/io/eval.rs
+++ b/src/io/eval.rs
@@ -2,9 +2,11 @@ use super::{utils::*, Obfuscation, ObfuscationParams};
 use crate::{
     bgg::{sampler::BGGPublicKeySampler, BggEncoding},
     poly::{matrix::*, sampler::*, Poly, PolyElem, PolyParams},
+    utils::log_mem,
 };
 use itertools::Itertools;
 use std::{ops::Mul, sync::Arc};
+use tracing::info;
 
 impl<M> Obfuscation<M>
 where
@@ -50,9 +52,9 @@ where
                 let gadget_2 = M::gadget_matrix(&params, 2);
                 M::from_poly_vec_row(params.as_ref(), polys).tensor(&gadget_2)
             };
-            let expected_encoding_init = &self.s_init
-                * &(public_data.pubkeys[0][0].concat_matrix(&public_data.pubkeys[0][1..])
-                    - inserted_poly_gadget);
+            let expected_encoding_init = &self.s_init *
+                &(public_data.pubkeys[0][0].concat_matrix(&public_data.pubkeys[0][1..]) -
+                    inserted_poly_gadget);
             debug_assert_eq!(
                 encodings[0][0].concat_vector(&encodings[0][1..]),
                 expected_encoding_init
@@ -82,8 +84,11 @@ where
                 let t = if *input { &public_data.rgs[1] } else { &public_data.rgs[0] };
                 let encode_vec = encodings[idx][0].concat_vector(&encodings[idx][1..]);
                 let packed_input_size = obf_params.input_size.div_ceil(dim) + 1;
+                info!("🍕");
+                log_mem();
                 encode_vec.mul_tensor_identity_decompose(t, packed_input_size + 1) + v
             };
+            log_mem();
             let mut new_encodings = vec![];
             // let zero_poly = <M::P as Poly>::const_zero(&params);
             // let one_poly = <M::P as Poly>::const_one(&params);
@@ -209,10 +214,10 @@ where
                 .collect::<Vec<_>>();
             debug_assert_eq!(output_plaintext, hardcoded_key_bits);
             {
-                let expcted = last_s
-                    * (output_encodings[0].pubkey.matrix.clone()
-                        - M::gadget_matrix(&params, 2)
-                            * output_encodings[0].plaintext.clone().unwrap());
+                let expcted = last_s *
+                    (output_encodings[0].pubkey.matrix.clone() -
+                        M::gadget_matrix(&params, 2) *
+                            output_encodings[0].plaintext.clone().unwrap());
                 debug_assert_eq!(output_encodings[0].vector, expcted);
             }
 

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -50,14 +50,11 @@ mod test {
             },
             PolyParams,
         },
+        utils::init_tracing,
     };
     use keccak_asm::Keccak256;
     use num_bigint::BigUint;
     use std::sync::Arc;
-
-    fn init_tracing() {
-        tracing_subscriber::fmt::init();
-    }
 
     #[test]
     fn test_io_just_mul_enc_and_bit() {

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -114,7 +114,6 @@ mod test {
     }
 
     #[test]
-    #[ignore]
     fn test_io_just_mul_enc_and_bit_real_params() {
         init_tracing();
         let start_time = std::time::Instant::now();

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -114,6 +114,7 @@ mod test {
     }
 
     #[test]
+    #[ignore]
     fn test_io_just_mul_enc_and_bit_real_params() {
         init_tracing();
         let start_time = std::time::Instant::now();

--- a/src/io/obf.rs
+++ b/src/io/obf.rs
@@ -158,7 +158,13 @@ where
         info!("aft np computed");
 
         let k_preimage = |bit: usize| {
-            info!("🟢 :{} | {}", public_data.pubkeys.len(), public_data.pubkeys[0].len());
+            info!(
+                "🟢 :{} | {} | {} | {}",
+                public_data.pubkeys.len(),
+                public_data.pubkeys[0].len(),
+                public_data.pubkeys[idx][0].matrix.col_size(),
+                public_data.pubkeys[idx][0].matrix.row_size()
+            );
             let rg = &public_data.rgs[bit];
             log_mem();
             let lhs = -public_data.pubkeys[idx][0].concat_matrix(&public_data.pubkeys[idx][1..]);
@@ -169,10 +175,8 @@ where
             let inserted_coeff_index = idx % dim;
             let zero_coeff = <M::P as Poly>::Elem::zero(&params.modulus());
             let mut coeffs = vec![zero_coeff; dim];
-            coeffs[inserted_coeff_index] = if bit == 0 {
-                <M::P as Poly>::Elem::zero(&params.modulus())
-            } else {
-                <M::P as Poly>::Elem::one(&params.modulus())
+            if bit != 0 {
+                coeffs[inserted_coeff_index] = <M::P as Poly>::Elem::one(&params.modulus())
             };
             let inserted_poly = M::P::from_coeffs(params.as_ref(), &coeffs);
             let inserted_poly_gadget = {

--- a/src/io/obf.rs
+++ b/src/io/obf.rs
@@ -143,7 +143,9 @@ where
         let k_preimage = |bit: usize| {
             let rg = &public_data.rgs[bit];
             let lhs = -public_data.pubkeys[idx][0].concat_matrix(&public_data.pubkeys[idx][1..]);
+            info!("lhs computed");
             let top = lhs.mul_tensor_identity_decompose(rg, 1 + packed_input_size);
+            info!("top computed");
             let inserted_poly_index = 1 + idx / dim;
             let inserted_coeff_index = idx % dim;
             let zero_coeff = <M::P as Poly>::Elem::zero(&params.modulus());
@@ -167,17 +169,18 @@ where
                 M::from_poly_vec_row(params.as_ref(), polys).tensor(&gadget_2)
             };
             let bottom = public_data.pubkeys[idx + 1][0]
-                .concat_matrix(&public_data.pubkeys[idx + 1][1..])
-                - &inserted_poly_gadget;
+                .concat_matrix(&public_data.pubkeys[idx + 1][1..]) -
+                &inserted_poly_gadget;
             let k_target = top.concat_rows(&[&bottom]);
             let b_matrix = if bit == 0 { b_next_0 } else { b_next_1 };
             let trapdoor = if bit == 0 { b_next_0_trapdoor } else { b_next_1_trapdoor };
             sampler_trapdoor.preimage(&params, trapdoor, b_matrix, &k_target)
         };
+        info!("before kp computed");
         let kp = || join!(|| k_preimage(0), || k_preimage(1));
-
+        info!("kp computed");
         let (mp, (np, kp)) = join!(mp, || join!(np, kp));
-
+        info!("mp computed");
         m_preimages.push(mp);
         n_preimages.push(np);
         k_preimages.push(kp);

--- a/src/io/obf.rs
+++ b/src/io/obf.rs
@@ -117,16 +117,27 @@ where
         let (_, _, b_cur_star_trapdoor) = &b_trapdoors[idx];
         let (b_next_0_trapdoor, b_next_1_trapdoor, _) = &b_trapdoors[idx + 1];
         info!("before m_preimage computed");
-        let m_preimage =
-            |a| sampler_trapdoor.preimage(params.as_ref(), b_cur_star_trapdoor, b_cur_star, &a);
+        let m_preimage = |a| {
+            info!("🍕 do we get m_preimage");
+            sampler_trapdoor.preimage(params.as_ref(), b_cur_star_trapdoor, b_cur_star, &a)
+        };
         info!("aft m_preimage computed");
         log_mem();
-        let mp = || join!(|| m_preimage(&u_0 * b_next_0), || m_preimage(&u_1 * b_next_1));
+
+        let mp = || {
+            info!("🍕🍕  do we get mp");
+            join!(|| m_preimage(&u_0 * b_next_0), || m_preimage(&u_1 * b_next_1))
+        };
         info!("aft mp computed");
         log_mem();
         let ub_star = &u_star * b_next_star;
-        let n_preimage = |t, n| sampler_trapdoor.preimage(&params, t, n, &ub_star);
+        // todo: 36gb
+        let n_preimage = |t, n| {
+            info!("🍕🍕🍕🍕 do we get n_preimage?");
+            sampler_trapdoor.preimage(&params, t, n, &ub_star)
+        };
         let np = || {
+            info!("🍕🍕🍕   do we get np?");
             join!(|| n_preimage(b_next_0_trapdoor, b_next_0), || n_preimage(
                 b_next_1_trapdoor,
                 b_next_1
@@ -172,7 +183,10 @@ where
             info!("before preimage computed");
             sampler_trapdoor.preimage(&params, trapdoor, b_matrix, &k_target)
         };
-        let kp = || join!(|| k_preimage(0), || k_preimage(1));
+        let kp = || {
+            info!("🍕🔥 do we get kp?");
+            join!(|| k_preimage(0), || k_preimage(1))
+        };
         log_mem();
         info!("kp computed");
         let (mp, (np, kp)) = join!(mp, || join!(np, kp));

--- a/src/io/obf.rs
+++ b/src/io/obf.rs
@@ -144,10 +144,11 @@ where
             ))
         };
         info!("aft np computed");
-        log_mem();
 
         let k_preimage = |bit: usize| {
+            info!("🟢 :{} | {}", public_data.pubkeys.len(), public_data.pubkeys[0].len());
             let rg = &public_data.rgs[bit];
+            log_mem();
             let lhs = -public_data.pubkeys[idx][0].concat_matrix(&public_data.pubkeys[idx][1..]);
             info!("lhs computed");
             let top = lhs.mul_tensor_identity_decompose(rg, 1 + packed_input_size);
@@ -185,6 +186,7 @@ where
         };
         let kp = || {
             info!("🍕🔥 do we get kp?");
+            log_mem();
             join!(|| k_preimage(0), || k_preimage(1))
         };
         log_mem();

--- a/src/io/obf.rs
+++ b/src/io/obf.rs
@@ -141,9 +141,9 @@ where
         };
 
         let k_preimage = |bit: usize| {
-            let rg_decomposed = &public_data.rgs_decomposed[bit];
+            let rg = &public_data.rgs[bit];
             let lhs = -public_data.pubkeys[idx][0].concat_matrix(&public_data.pubkeys[idx][1..]);
-            let top = lhs.mul_tensor_identity(rg_decomposed, 1 + packed_input_size);
+            let top = lhs.mul_tensor_identity_decompose(rg, 1 + packed_input_size);
             let inserted_poly_index = 1 + idx / dim;
             let inserted_coeff_index = idx % dim;
             let zero_coeff = <M::P as Poly>::Elem::zero(&params.modulus());
@@ -167,8 +167,8 @@ where
                 M::from_poly_vec_row(params.as_ref(), polys).tensor(&gadget_2)
             };
             let bottom = public_data.pubkeys[idx + 1][0]
-                .concat_matrix(&public_data.pubkeys[idx + 1][1..]) -
-                &inserted_poly_gadget;
+                .concat_matrix(&public_data.pubkeys[idx + 1][1..])
+                - &inserted_poly_gadget;
             let k_target = top.concat_rows(&[&bottom]);
             let b_matrix = if bit == 0 { b_next_0 } else { b_next_1 };
             let trapdoor = if bit == 0 { b_next_0_trapdoor } else { b_next_1_trapdoor };

--- a/src/io/obf.rs
+++ b/src/io/obf.rs
@@ -125,13 +125,13 @@ where
         let (b_next_0, b_next_1, b_next_star) = &bs[idx + 1];
         let (_, _, b_cur_star_trapdoor) = &b_trapdoors[idx];
         let (b_next_0_trapdoor, b_next_1_trapdoor, _) = &b_trapdoors[idx + 1];
-
+        info!("before m_preimage computed");
         let m_preimage =
             |a| sampler_trapdoor.preimage(params.as_ref(), b_cur_star_trapdoor, b_cur_star, &a);
-        let mp =
-            || join!(|| m_preimage(u_0.clone() * b_next_0), || m_preimage(u_1.clone() * b_next_1));
+        info!("aft m_preimage computed");
+        let mp = || join!(|| m_preimage(&u_0 * b_next_0), || m_preimage(&u_1 * b_next_1));
 
-        let ub_star = u_star.clone() * b_next_star;
+        let ub_star = &u_star * b_next_star;
         let n_preimage = |t, n| sampler_trapdoor.preimage(&params, t, n, &ub_star);
         let np = || {
             join!(|| n_preimage(b_next_0_trapdoor, b_next_0), || n_preimage(
@@ -174,6 +174,7 @@ where
             let k_target = top.concat_rows(&[&bottom]);
             let b_matrix = if bit == 0 { b_next_0 } else { b_next_1 };
             let trapdoor = if bit == 0 { b_next_0_trapdoor } else { b_next_1_trapdoor };
+            info!("before preimage computed");
             sampler_trapdoor.preimage(&params, trapdoor, b_matrix, &k_target)
         };
         info!("before kp computed");

--- a/src/io/obf.rs
+++ b/src/io/obf.rs
@@ -119,14 +119,20 @@ where
         info!("before m_preimage computed");
         let m_preimage = |a| {
             info!("🍕 do we get m_preimage");
-            sampler_trapdoor.preimage(params.as_ref(), b_cur_star_trapdoor, b_cur_star, &a)
+            log_mem();
+            let r = sampler_trapdoor.preimage(params.as_ref(), b_cur_star_trapdoor, b_cur_star, &a);
+            log_mem();
+            r
         };
         info!("aft m_preimage computed");
         log_mem();
 
         let mp = || {
             info!("🍕🍕  do we get mp");
-            join!(|| m_preimage(&u_0 * b_next_0), || m_preimage(&u_1 * b_next_1))
+            log_mem();
+            let r = join!(|| m_preimage(&u_0 * b_next_0), || m_preimage(&u_1 * b_next_1));
+            log_mem();
+            r
         };
         info!("aft mp computed");
         log_mem();
@@ -134,14 +140,20 @@ where
         // todo: 36gb
         let n_preimage = |t, n| {
             info!("🍕🍕🍕🍕 do we get n_preimage?");
-            sampler_trapdoor.preimage(&params, t, n, &ub_star)
+            log_mem();
+            let r = sampler_trapdoor.preimage(&params, t, n, &ub_star);
+            log_mem();
+            r
         };
         let np = || {
             info!("🍕🍕🍕   do we get np?");
-            join!(|| n_preimage(b_next_0_trapdoor, b_next_0), || n_preimage(
+            log_mem();
+            let r = join!(|| n_preimage(b_next_0_trapdoor, b_next_0), || n_preimage(
                 b_next_1_trapdoor,
                 b_next_1
-            ))
+            ));
+            log_mem();
+            r
         };
         info!("aft np computed");
 
@@ -187,7 +199,9 @@ where
         let kp = || {
             info!("🍕🔥 do we get kp?");
             log_mem();
-            join!(|| k_preimage(0), || k_preimage(1))
+            let r = join!(|| k_preimage(0), || k_preimage(1));
+            log_mem();
+            r
         };
         log_mem();
         info!("kp computed");

--- a/src/io/utils.rs
+++ b/src/io/utils.rs
@@ -86,8 +86,9 @@ where
         info!("pubkeys computed");
         let gadget_2 = S::M::gadget_matrix(params, 2);
         // let identity_2 = S::M::identity(params, 2, None);
+        // todo: note this is not decomposed
         let rgs_decomposed: [<S as PolyHashSampler<[u8; 32]>>::M; 2] =
-            [(&r_0 * &gadget_2).decompose(), (&r_1 * &gadget_2).decompose()];
+            [(&r_0 * &gadget_2), (&r_1 * &gadget_2)];
 
         let a_prf_raw = hash_sampler.sample_hash(
             params,

--- a/src/io/utils.rs
+++ b/src/io/utils.rs
@@ -1,5 +1,4 @@
 use itertools::Itertools;
-use tracing::info;
 
 use super::ObfuscationParams;
 use crate::{
@@ -372,9 +371,9 @@ mod test {
                 &params,
                 vec![outputs_encodings[0].plaintext.clone().unwrap()],
             );
-            bgg_encoding_sampler.secret_vec
-                * (outputs_encodings[0].pubkey.matrix.clone()
-                    - plaintext.tensor(&DCRTPolyMatrix::gadget_matrix(&params, 2)))
+            bgg_encoding_sampler.secret_vec *
+                (outputs_encodings[0].pubkey.matrix.clone() -
+                    plaintext.tensor(&DCRTPolyMatrix::gadget_matrix(&params, 2)))
         };
         assert_eq!(outputs_encodings[0].vector, expected_vector);
     }

--- a/src/io/utils.rs
+++ b/src/io/utils.rs
@@ -26,7 +26,7 @@ pub struct PublicSampledData<S: PolyHashSampler<[u8; 32]>> {
     pub a_rlwe_bar: S::M,
     pub pubkeys: Vec<Vec<BggPublicKey<S::M>>>,
     // pub pubkeys_fhe_key: Vec<Vec<BggPublicKey<S::M>>>,
-    pub rgs_decomposed: [S::M; 2],
+    pub rgs: [S::M; 2],
     pub a_prf: S::M,
     pub packed_input_size: usize,
     pub packed_output_size: usize,
@@ -86,8 +86,7 @@ where
         info!("pubkeys computed");
         let gadget_2 = S::M::gadget_matrix(params, 2);
         // let identity_2 = S::M::identity(params, 2, None);
-        // todo: note this is not decomposed
-        let rgs_decomposed: [<S as PolyHashSampler<[u8; 32]>>::M; 2] =
+        let rgs: [<S as PolyHashSampler<[u8; 32]>>::M; 2] =
             [(&r_0 * &gadget_2), (&r_1 * &gadget_2)];
 
         let a_prf_raw = hash_sampler.sample_hash(
@@ -105,7 +104,7 @@ where
             r_1,
             a_rlwe_bar,
             pubkeys,
-            rgs_decomposed,
+            rgs,
             a_prf,
             packed_input_size,
             packed_output_size,
@@ -380,9 +379,9 @@ mod test {
                 &params,
                 vec![outputs_encodings[0].plaintext.clone().unwrap()],
             );
-            bgg_encoding_sampler.secret_vec *
-                (outputs_encodings[0].pubkey.matrix.clone() -
-                    plaintext.tensor(&DCRTPolyMatrix::gadget_matrix(&params, 2)))
+            bgg_encoding_sampler.secret_vec
+                * (outputs_encodings[0].pubkey.matrix.clone()
+                    - plaintext.tensor(&DCRTPolyMatrix::gadget_matrix(&params, 2)))
         };
         assert_eq!(outputs_encodings[0].vector, expected_vector);
     }

--- a/src/io/utils.rs
+++ b/src/io/utils.rs
@@ -379,9 +379,9 @@ mod test {
                 &params,
                 vec![outputs_encodings[0].plaintext.clone().unwrap()],
             );
-            bgg_encoding_sampler.secret_vec
-                * (outputs_encodings[0].pubkey.matrix.clone()
-                    - plaintext.tensor(&DCRTPolyMatrix::gadget_matrix(&params, 2)))
+            bgg_encoding_sampler.secret_vec *
+                (outputs_encodings[0].pubkey.matrix.clone() -
+                    plaintext.tensor(&DCRTPolyMatrix::gadget_matrix(&params, 2)))
         };
         assert_eq!(outputs_encodings[0].vector, expected_vector);
     }

--- a/src/io/utils.rs
+++ b/src/io/utils.rs
@@ -44,9 +44,7 @@ where
         let hash_sampler = &bgg_pubkey_sampler.sampler;
         let params = &obf_params.params;
         let r_0_bar = hash_sampler.sample_hash(params, TAG_R_0, 1, 1, DistType::BitDist);
-        info!("r_0_bar computed");
         let r_1_bar = hash_sampler.sample_hash(params, TAG_R_1, 1, 1, DistType::BitDist);
-        info!("r_1_bar computed");
         let one = S::M::identity(params, 1, None);
         let r_0 = r_0_bar.concat_diag(&[&one]);
         let r_1 = r_1_bar.concat_diag(&[&one]);
@@ -57,7 +55,6 @@ where
         let packed_output_size = obf_params.public_circuit.num_output() / log_q;
         let a_rlwe_bar =
             hash_sampler.sample_hash(params, TAG_A_RLWE_BAR, 1, 1, DistType::FinRingDist);
-        info!("a_rlwe_bar computed");
         // let reveal_plaintexts_fhe_key = vec![true; 2];
         #[cfg(test)]
         let reveal_plaintexts = [vec![true; packed_input_size - 1], vec![true; 1]].concat();
@@ -65,7 +62,6 @@ where
         let reveal_plaintexts = [vec![true; packed_input_size - 1], vec![false; 1]].concat();
         let pubkeys = (0..obf_params.input_size + 1)
             .map(|idx| {
-                info!("try pubkey 1 computed");
                 bgg_pubkey_sampler.sample(
                     params,
                     &[TAG_BGG_PUBKEY_INPUT_PREFIX, &idx.to_le_bytes()].concat(),
@@ -83,7 +79,6 @@ where
         //     })
         //     .collect_vec();
         // let identity_input = S::M::identity(params, 1 + packed_input_size, None);
-        info!("pubkeys computed");
         let gadget_2 = S::M::gadget_matrix(params, 2);
         // let identity_2 = S::M::identity(params, 2, None);
         let rgs: [<S as PolyHashSampler<[u8; 32]>>::M; 2] =
@@ -96,9 +91,7 @@ where
             packed_output_size,
             DistType::FinRingDist,
         );
-        info!("a_prf_raw computed");
         let a_prf = a_prf_raw.modulus_switch(&obf_params.switched_modulus);
-        info!("modulus_switch");
         Self {
             r_0,
             r_1,
@@ -379,9 +372,9 @@ mod test {
                 &params,
                 vec![outputs_encodings[0].plaintext.clone().unwrap()],
             );
-            bgg_encoding_sampler.secret_vec *
-                (outputs_encodings[0].pubkey.matrix.clone() -
-                    plaintext.tensor(&DCRTPolyMatrix::gadget_matrix(&params, 2)))
+            bgg_encoding_sampler.secret_vec
+                * (outputs_encodings[0].pubkey.matrix.clone()
+                    - plaintext.tensor(&DCRTPolyMatrix::gadget_matrix(&params, 2)))
         };
         assert_eq!(outputs_encodings[0].vector, expected_vector);
     }

--- a/src/poly/dcrt/matrix.rs
+++ b/src/poly/dcrt/matrix.rs
@@ -351,8 +351,7 @@ impl PolyMatrix for DCRTPolyMatrix {
     fn mul_tensor_identity_decompose(&self, other: &Self, identity_size: usize) -> Self {
         assert_eq!(self.ncol, other.nrow * identity_size * self.params.modulus_bits());
         let slice_width = other.ncol;
-        let mut output =
-            vec![DCRTPolyMatrix::zero(&self.params, self.nrow, 1); other.ncol * identity_size];
+        let mut output = vec![DCRTPolyMatrix::zero(&self.params, 0, 0); other.ncol * identity_size];
 
         for j in 0..other.ncol {
             let jth_col_m = other.get_column_matrix(j);

--- a/src/poly/dcrt/matrix.rs
+++ b/src/poly/dcrt/matrix.rs
@@ -760,8 +760,6 @@ mod tests {
 
     #[test]
     fn test_mul_tensor_identity_decompose_naive() {
-        info!("before naive");
-        log_mem();
         let params = DCRTPolyParams::default();
         let sampler = DCRTPolyUniformSampler::new();
 
@@ -773,16 +771,11 @@ mod tests {
         let other =
             sampler.sample_uniform(&params, 2, 68, crate::poly::sampler::DistType::FinRingDist);
 
-        info!("before operation naive");
-        log_mem();
-
         // Decompose 'other' matrix
         let other_decompose = other.decompose();
 
         // Perform S * (I_37 ⊗ G^-1(other))
         let result: DCRTPolyMatrix = s.mul_tensor_identity(&other_decompose, 37);
-        info!("after operation naive");
-        log_mem();
 
         // Check dimensions
         assert_eq!(result.row_size(), 2);
@@ -800,8 +793,6 @@ mod tests {
 
     #[test]
     fn test_mul_tensor_identity_decompose_optimal() {
-        info!("before optimal");
-        log_mem();
         let params = DCRTPolyParams::default();
         let sampler = DCRTPolyUniformSampler::new();
 
@@ -814,11 +805,7 @@ mod tests {
             sampler.sample_uniform(&params, 2, 68, crate::poly::sampler::DistType::FinRingDist);
 
         // Perform S * (I_37 ⊗ G^-1(other))
-        info!("before operation optimal");
-        log_mem();
         let result: DCRTPolyMatrix = s.mul_tensor_identity_decompose(&other, 37);
-        info!("after operation optimal");
-        log_mem();
 
         // // Check dimensions
         assert_eq!(result.row_size(), 2);

--- a/src/poly/dcrt/matrix.rs
+++ b/src/poly/dcrt/matrix.rs
@@ -540,15 +540,11 @@ mod tests {
     use std::sync::Arc;
 
     use num_bigint::BigUint;
-    use tracing::info;
 
     use super::*;
-    use crate::{
-        poly::{
-            dcrt::{DCRTPolyParams, DCRTPolyUniformSampler},
-            sampler::PolyUniformSampler,
-        },
-        utils::{init_tracing, log_mem},
+    use crate::poly::{
+        dcrt::{DCRTPolyParams, DCRTPolyUniformSampler},
+        sampler::PolyUniformSampler,
     };
 
     #[test]

--- a/src/poly/dcrt/matrix.rs
+++ b/src/poly/dcrt/matrix.rs
@@ -549,7 +549,7 @@ mod tests {
             dcrt::{DCRTPolyParams, DCRTPolyUniformSampler},
             sampler::PolyUniformSampler,
         },
-        utils::log_mem,
+        utils::{init_tracing, log_mem},
     };
 
     #[test]
@@ -761,7 +761,6 @@ mod tests {
 
     #[test]
     fn test_mul_tensor_identity_decompose_naive() {
-        tracing_subscriber::fmt::init();
         info!("before naive");
         log_mem();
         let params = DCRTPolyParams::default();
@@ -802,7 +801,6 @@ mod tests {
 
     #[test]
     fn test_mul_tensor_identity_decompose_optimal() {
-        tracing_subscriber::fmt::init();
         info!("before optimal");
         log_mem();
         let params = DCRTPolyParams::default();

--- a/src/poly/dcrt/sampler/hash.rs
+++ b/src/poly/dcrt/sampler/hash.rs
@@ -12,7 +12,6 @@ use num_bigint::BigUint;
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 use std::marker::PhantomData;
-use tracing::info;
 
 pub struct DCRTPolyHashSampler<H: OutputSizeUser + digest::Digest> {
     key: [u8; 32],
@@ -48,7 +47,6 @@ where
         }
 
         // From field elements to nrow * ncol polynomials
-        let total_poly = nrow * ncol;
         DCRTPolyMatrix::from_poly_vec(
             params,
             parallel_iter!(0..nrow)

--- a/src/poly/dcrt/sampler/hash.rs
+++ b/src/poly/dcrt/sampler/hash.rs
@@ -49,7 +49,6 @@ where
 
         // From field elements to nrow * ncol polynomials
         let total_poly = nrow * ncol;
-        info!("total_poly {} {} {}", total_poly, ncol, nrow);
         DCRTPolyMatrix::from_poly_vec(
             params,
             parallel_iter!(0..nrow)
@@ -98,7 +97,6 @@ where
                 let mut og_hasher: H = H::new();
                 og_hasher.update(self.key);
                 og_hasher.update(tag.as_ref());
-                info!("before loop {}, {}", index, bit_length);
                 for i in 0..index {
                     let mut hasher = og_hasher.clone();
                     //  H ( key || tag || i )
@@ -109,7 +107,6 @@ where
                         }
                     }
                 }
-                info!(?bit_length, "finished hasher, bv length {}", bv.len());
                 let num_chunks = bv.len() / bit_length;
                 let ring_elems: Vec<FinRingElem> = parallel_iter!(0..num_chunks)
                     .map(|i| {
@@ -127,7 +124,6 @@ where
                         FinRingElem::new(value, q.clone())
                     })
                     .collect();
-                info!("finished ring_elems");
                 debug_assert_eq!(ring_elems.len(), (index * hash_output_size) / bit_length);
                 ring_elems
             }

--- a/src/poly/dcrt/sampler/trapdoor.rs
+++ b/src/poly/dcrt/sampler/trapdoor.rs
@@ -90,13 +90,14 @@ impl PolyTrapdoorSampler for DCRTPolyTrapdoorSampler {
         let rlwe_trapdoor = dcrt_trapdoor.get_trapdoor_pair();
         let nrow = size;
         let ncol = (&params.modulus_bits() + 2) * size;
-
-        let matrix_inner: Vec<Vec<_>> = parallel_iter!(0..nrow)
-            .map(|i| {
-                parallel_iter!(0..ncol).map(|j| dcrt_trapdoor.get_public_matrix(i, j)).collect()
-            })
-            .collect();
-        let public_matrix = DCRTPolyMatrix::from_poly_vec(params, matrix_inner);
+        let public_matrix = DCRTPolyMatrix::from_poly_vec(
+            params,
+            parallel_iter!(0..nrow)
+                .map(|i| {
+                    parallel_iter!(0..ncol).map(|j| dcrt_trapdoor.get_public_matrix(i, j)).collect()
+                })
+                .collect(),
+        );
         (rlwe_trapdoor, public_matrix)
     }
 

--- a/src/poly/matrix.rs
+++ b/src/poly/matrix.rs
@@ -92,4 +92,7 @@ pub trait PolyMatrix:
     ) -> Self;
     /// Performs the operation S * (identity ⊗ other)
     fn mul_tensor_identity(&self, other: &Self, identity_size: usize) -> Self;
+    /// Performs the operation S * (identity ⊗ G^-1(other)),
+    /// where G^-1(other) is bit decomposition of other matrix
+    fn mul_tensor_identity_decompose(&self, other: &Self, identity_size: usize) -> Self;
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -83,6 +83,10 @@ pub fn log_mem() {
     }
 }
 
+pub fn init_tracing() {
+    tracing_subscriber::fmt::init();
+}
+
 #[macro_export]
 macro_rules! parallel_iter {
     ($i: expr) => {{


### PR DESCRIPTION
`mul_tensor_identity_decompose` method on `PolyMatrix` performs the operation `S * (identity ⊗ G^-1(other))`, where G^-1(other) is bit decomposition of other matrix.

We introducing this optimization as `(identity ⊗ G^-1(other))` takes up too much memory. Instead, we chunk into column matrix and streaming multiplication with bit decomposed column and identity so to reduce peak memory consumption