### PR TITLE
perf: `.get_column_matrix_decompose`

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,5 +12,5 @@ cargo test -r  --features="parallel"
 this will remove helper logic + helper fields for test which is not require for iO security.
 
 ```
-cargo test --test test_io --no-default-features --features parallel
+/usr/bin/time -l cargo test --test test_io --no-default-features --features parallel
 ```

--- a/src/bgg/sampler.rs
+++ b/src/bgg/sampler.rs
@@ -54,7 +54,6 @@ where
         let secret_vec_size = self.d + 1;
         let columns = secret_vec_size * log_q;
         let packed_input_size = 1 + reveal_plaintexts.len(); // first slot is allocated to the constant 1 polynomial plaintext
-        info!("before all_matrix");
         let all_matrix = self.sampler.sample_hash(
             params,
             tag,
@@ -62,8 +61,6 @@ where
             columns * packed_input_size,
             DistType::FinRingDist,
         );
-        info!("all_matrix");
-
         parallel_iter!(0..packed_input_size)
             .map(|idx| {
                 let reveal_plaintext = if idx == 0 { true } else { reveal_plaintexts[idx - 1] };

--- a/src/io/eval.rs
+++ b/src/io/eval.rs
@@ -153,8 +153,10 @@ where
                 debug_assert_eq!(new_encode_vec, expcted_new_encode);
             }
         }
-        let enc_hardcoded_key_decomposed = &self.enc_hardcoded_key.get_column_matrix_decompose(0);
-        let a_decomposed_polys = public_data.a_rlwe_bar.get_column_matrix_decompose(0);
+        let enc_hardcoded_key_decomposed =
+            &self.enc_hardcoded_key.get_column_matrix_decompose(0).get_column(0);
+        let a_decomposed_polys =
+            public_data.a_rlwe_bar.get_column_matrix_decompose(0).get_column(0);
         let final_circuit = build_final_bits_circuit::<M::P, BggEncoding<M>>(
             &a_decomposed_polys,
             enc_hardcoded_key_decomposed,

--- a/src/io/eval.rs
+++ b/src/io/eval.rs
@@ -153,8 +153,8 @@ where
                 debug_assert_eq!(new_encode_vec, expcted_new_encode);
             }
         }
-        let enc_hardcoded_key_decomposed = &self.enc_hardcoded_key.decompose().get_column(0);
-        let a_decomposed_polys = public_data.a_rlwe_bar.decompose().get_column(0);
+        let enc_hardcoded_key_decomposed = &self.enc_hardcoded_key.get_column_matrix_decompose(0);
+        let a_decomposed_polys = public_data.a_rlwe_bar.get_column_matrix_decompose(0);
         let final_circuit = build_final_bits_circuit::<M::P, BggEncoding<M>>(
             &a_decomposed_polys,
             enc_hardcoded_key_decomposed,

--- a/src/io/obf.rs
+++ b/src/io/obf.rs
@@ -64,7 +64,7 @@ where
         &t_bar_matrix * &public_data.a_rlwe_bar + &e - &(&hardcoded_key_matrix * &scale)
     };
 
-    let enc_hardcoded_key_polys = enc_hardcoded_key.decompose().get_column(0);
+    let enc_hardcoded_key_polys = enc_hardcoded_key.get_column_matrix_decompose(0);
     let t_bar = t_bar_matrix.entry(0, 0).clone();
     #[cfg(feature = "test")]
     let hardcoded_key = hardcoded_key_matrix.entry(0, 0).clone();
@@ -173,7 +173,7 @@ where
         k_preimages.push(kp);
     }
 
-    let a_decomposed_polys = public_data.a_rlwe_bar.decompose().get_column(0);
+    let a_decomposed_polys = public_data.a_rlwe_bar.get_column_matrix_decompose(0);
     let final_circuit = build_final_bits_circuit::<M::P, BggPublicKey<M>>(
         &a_decomposed_polys,
         &enc_hardcoded_key_polys,

--- a/src/io/obf.rs
+++ b/src/io/obf.rs
@@ -64,7 +64,7 @@ where
         &t_bar_matrix * &public_data.a_rlwe_bar + &e - &(&hardcoded_key_matrix * &scale)
     };
 
-    let enc_hardcoded_key_polys = enc_hardcoded_key.get_column_matrix_decompose(0);
+    let enc_hardcoded_key_polys = enc_hardcoded_key.get_column_matrix_decompose(0).get_column(0);
     let t_bar = t_bar_matrix.entry(0, 0).clone();
     #[cfg(feature = "test")]
     let hardcoded_key = hardcoded_key_matrix.entry(0, 0).clone();
@@ -173,7 +173,7 @@ where
         k_preimages.push(kp);
     }
 
-    let a_decomposed_polys = public_data.a_rlwe_bar.get_column_matrix_decompose(0);
+    let a_decomposed_polys = public_data.a_rlwe_bar.get_column_matrix_decompose(0).get_column(0);
     let final_circuit = build_final_bits_circuit::<M::P, BggPublicKey<M>>(
         &a_decomposed_polys,
         &enc_hardcoded_key_polys,

--- a/src/io/obf.rs
+++ b/src/io/obf.rs
@@ -6,10 +6,12 @@ use crate::{
     },
     join,
     poly::{matrix::*, sampler::*, Poly, PolyElem, PolyParams},
+    utils::log_mem,
 };
 use itertools::Itertools;
 use rand::{Rng, RngCore};
 use std::{ops::Mul, sync::Arc};
+use tracing::info;
 
 pub fn obfuscate<M, SU, SH, ST, R>(
     obf_params: ObfuscationParams<M>,
@@ -39,11 +41,13 @@ where
     let sampler_trapdoor = Arc::new(sampler_trapdoor);
     let bgg_pubkey_sampler = BGGPublicKeySampler::new(Arc::new(sampler_hash), d);
     let public_data = PublicSampledData::sample(&obf_params, &bgg_pubkey_sampler);
+    log_mem("Sampled public data");
     let params = Arc::new(obf_params.params);
     let packed_input_size = public_data.packed_input_size;
     let packed_output_size = public_data.packed_output_size;
     let s_bars =
         sampler_uniform.sample_uniform(&params, 1, d, DistType::BitDist).get_row(0).clone();
+    log_mem("Sampled s_bars");
     let bgg_encode_sampler = BGGEncodingSampler::new(
         params.as_ref(),
         &s_bars,
@@ -63,8 +67,9 @@ where
         let scale = M::P::from_const(&params, &<M::P as Poly>::Elem::half_q(&params.modulus()));
         &t_bar_matrix * &public_data.a_rlwe_bar + &e - &(&hardcoded_key_matrix * &scale)
     };
-
+    log_mem("Sampled enc_hardcoded_key");
     let enc_hardcoded_key_polys = enc_hardcoded_key.get_column_matrix_decompose(0).get_column(0);
+
     let t_bar = t_bar_matrix.entry(0, 0).clone();
     #[cfg(feature = "test")]
     let hardcoded_key = hardcoded_key_matrix.entry(0, 0).clone();
@@ -73,6 +78,7 @@ where
         .map(|_| M::P::const_zero(params.as_ref()))
         .collect_vec();
     plaintexts.push(t_bar.clone());
+    log_mem("Sampled plaintexts");
     let encodings_init = bgg_encode_sampler.sample(&params, &public_data.pubkeys[0], &plaintexts);
 
     let mut bs = Vec::with_capacity(obf_params.input_size);
@@ -84,6 +90,7 @@ where
         bs.push((b_0, b_1, b_star));
         b_trapdoors.push((b_0_trapdoor, b_1_trapdoor, b_star_trapdoor));
     }
+    log_mem("Sampled b_trapdoors,bs ");
     let m_b = (2 * d1) * (2 + log_q);
     let p_init = {
         let s_connect = s_init.concat_columns(&[s_init]);
@@ -167,7 +174,7 @@ where
         let kp = || join!(|| k_preimage(0), || k_preimage(1));
 
         let (mp, (np, kp)) = join!(mp, || join!(np, kp));
-
+        log_mem("Sampled mp,np,kp");
         m_preimages.push(mp);
         n_preimages.push(np);
         k_preimages.push(kp);
@@ -202,6 +209,7 @@ where
     let (_, _, b_final_trapdoor) = &b_trapdoors[obf_params.input_size];
     let final_preimage =
         sampler_trapdoor.preimage(&params, b_final_trapdoor, b_final, &final_preimage_target);
+    log_mem("Sampled final_preimage");
     Obfuscation {
         hash_key,
         enc_hardcoded_key,

--- a/src/io/utils.rs
+++ b/src/io/utils.rs
@@ -64,7 +64,6 @@ where
         let reveal_plaintexts = [vec![true; packed_input_size - 1], vec![false; 1]].concat();
         let pubkeys = (0..obf_params.input_size + 1)
             .map(|idx| {
-                info!("try pubkey 1 computed");
                 bgg_pubkey_sampler.sample(
                     params,
                     &[TAG_BGG_PUBKEY_INPUT_PREFIX, &idx.to_le_bytes()].concat(),
@@ -94,9 +93,7 @@ where
             packed_output_size,
             DistType::FinRingDist,
         );
-        info!("a_prf_raw computed");
         let a_prf = a_prf_raw.modulus_switch(&obf_params.switched_modulus);
-        info!("modulus_switch");
         Self {
             r_0,
             r_1,
@@ -207,11 +204,12 @@ mod test {
             t_bar.clone() * &a_rlwe_bar + &e - &(hardcoded_key.clone() * &scale);
 
         // 6. Decompose the ciphertext
-        let enc_hardcoded_key_polys = enc_hardcoded_key.decompose().get_column(0);
+        let enc_hardcoded_key_polys =
+            enc_hardcoded_key.get_column_matrix(0).decompose().get_column(0);
         // println!("enc_hardcoded_key_polys {}", enc_hardcoded_key_polys);
 
         // 7. Build the final step circuit with DCRTPoly as the Evaluable type
-        let a_decomposed_polys = a_rlwe_bar.decompose().get_column(0);
+        let a_decomposed_polys = a_rlwe_bar.get_column_matrix(0).decompose().get_column(0);
         let final_circuit = build_final_bits_circuit::<DCRTPoly, DCRTPoly>(
             &a_decomposed_polys,
             &enc_hardcoded_key_polys,

--- a/src/io/utils.rs
+++ b/src/io/utils.rs
@@ -205,11 +205,11 @@ mod test {
 
         // 6. Decompose the ciphertext
         let enc_hardcoded_key_polys =
-            enc_hardcoded_key.get_column_matrix(0).decompose().get_column(0);
+            enc_hardcoded_key.get_column_matrix_decompose(0).get_column(0);
         // println!("enc_hardcoded_key_polys {}", enc_hardcoded_key_polys);
 
         // 7. Build the final step circuit with DCRTPoly as the Evaluable type
-        let a_decomposed_polys = a_rlwe_bar.get_column_matrix(0).decompose().get_column(0);
+        let a_decomposed_polys = a_rlwe_bar.get_column_matrix_decompose(0).get_column(0);
         let final_circuit = build_final_bits_circuit::<DCRTPoly, DCRTPoly>(
             &a_decomposed_polys,
             &enc_hardcoded_key_polys,

--- a/src/poly/dcrt/matrix.rs
+++ b/src/poly/dcrt/matrix.rs
@@ -356,6 +356,15 @@ impl PolyMatrix for DCRTPolyMatrix {
 
         output[0].clone().concat_columns(&output[1..].iter().collect::<Vec<_>>())
     }
+
+    fn get_column_matrix_decompose(&self, j: usize) -> Vec<DCRTPoly> {
+        DCRTPolyMatrix::from_poly_vec(
+            &self.params,
+            self.get_column(j).into_iter().map(|poly| vec![poly]).collect(),
+        )
+        .decompose()
+        .get_column(0)
+    }
 }
 
 // ====== Arithmetic ======

--- a/src/poly/dcrt/matrix.rs
+++ b/src/poly/dcrt/matrix.rs
@@ -46,12 +46,6 @@ impl DCRTPolyMatrix {
     pub fn params(&self) -> &DCRTPolyParams {
         &self.params
     }
-
-    pub fn get_column_matrix(&self, j: usize) -> DCRTPolyMatrix {
-        let polys = self.get_column(j);
-        let column_vec: Vec<Vec<DCRTPoly>> = polys.into_iter().map(|poly| vec![poly]).collect();
-        DCRTPolyMatrix::from_poly_vec(&self.params, column_vec)
-    }
 }
 
 impl PolyMatrix for DCRTPolyMatrix {
@@ -346,8 +340,7 @@ impl PolyMatrix for DCRTPolyMatrix {
         let mut output = vec![DCRTPolyMatrix::zero(&self.params, 0, 0); other.ncol * identity_size];
 
         for j in 0..other.ncol {
-            let jth_col_m = other.get_column_matrix(j);
-            let jth_col_m_decompose = jth_col_m.decompose();
+            let jth_col_m_decompose = other.get_column_matrix_decompose(j);
             for i in 0..identity_size {
                 let slice = self.slice(0, self.nrow, i * slice_width, (i + 1) * slice_width);
                 output[i * other.ncol + j] = slice * &jth_col_m_decompose;
@@ -357,13 +350,12 @@ impl PolyMatrix for DCRTPolyMatrix {
         output[0].clone().concat_columns(&output[1..].iter().collect::<Vec<_>>())
     }
 
-    fn get_column_matrix_decompose(&self, j: usize) -> Vec<DCRTPoly> {
+    fn get_column_matrix_decompose(&self, j: usize) -> Self {
         DCRTPolyMatrix::from_poly_vec(
             &self.params,
             self.get_column(j).into_iter().map(|poly| vec![poly]).collect(),
         )
         .decompose()
-        .get_column(0)
     }
 }
 

--- a/src/poly/matrix.rs
+++ b/src/poly/matrix.rs
@@ -100,4 +100,6 @@ pub trait PolyMatrix:
     /// Performs the operation S * (identity ⊗ G^-1(other)),
     /// where G^-1(other) is bit decomposition of other matrix
     fn mul_tensor_identity_decompose(&self, other: &Self, identity_size: usize) -> Self;
+    /// j is column and return decomposed column matrix
+    fn get_column_matrix_decompose(&self, j: usize) -> Vec<Self::P>;
 }

--- a/src/poly/matrix.rs
+++ b/src/poly/matrix.rs
@@ -100,6 +100,6 @@ pub trait PolyMatrix:
     /// Performs the operation S * (identity ⊗ G^-1(other)),
     /// where G^-1(other) is bit decomposition of other matrix
     fn mul_tensor_identity_decompose(&self, other: &Self, identity_size: usize) -> Self;
-    /// j is column and return decomposed column matrix
-    fn get_column_matrix_decompose(&self, j: usize) -> Vec<Self::P>;
+    /// j is column and return decomposed matrix of target column
+    fn get_column_matrix_decompose(&self, j: usize) -> Self;
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -72,11 +72,13 @@ pub fn create_bit_poly(params: &DCRTPolyParams, bit: bool) -> DCRTPoly {
     }
 }
 
-pub fn log_mem() {
+pub fn log_mem<T: Into<String>>(tag: T) {
     if let Some(usage) = memory_stats() {
         info!(
-            "Current physical/virtural memory usage: {} / {}",
-            usage.physical_mem, usage.virtual_mem
+            "{} || Current physical/virtural memory usage: {} | {}",
+            tag.into(),
+            usage.physical_mem,
+            usage.virtual_mem
         );
     } else {
         info!("Couldn't get the current memory usage :(");


### PR DESCRIPTION
## description

before `decompose().get_column(0)`, first parse column vector matrix to make target decompose matrix size smaller


## perf

```
/usr/bin/time -l cargo test --test test_io --no-default-features --features parallel
```

### before
```
test result: ok. 1 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 98.85s

      100.35 real       787.32 user       233.41 sys
           333807616  maximum resident set size
                   0  average shared memory size
                   0  average unshared data size
                   0  average unshared stack size
               82128  page reclaims
                 122  page faults
                   0  swaps
                   0  block input operations
                   0  block output operations
                   0  messages sent
                   0  messages received
                   3  signals received
                  91  voluntary context switches
            21956714  involuntary context switches
           855483433  instructions retired
           280632294  cycles elapsed
            33031360  peak memory footprint
```

### after

```
test result: ok. 1 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 94.75s
       96.64 real       770.35 user       233.40 sys
           328237056  maximum resident set size
                   0  average shared memory size
                   0  average unshared data size
                   0  average unshared stack size
               76913  page reclaims
                5320  page faults
                   0  swaps
                   0  block input operations
                   0  block output operations
                   0  messages sent
                   0  messages received
                   3  signals received
                 349  voluntary context switches
            21848821  involuntary context switches
           850857882  instructions retired
           302300212  cycles elapsed
            32752896  peak memory footprint
```

