### PR TITLE
Replace `GetCoefficients` with  `GetCoefficientsBytes`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ test = []
 parallel = ["rayon"]
 
 [dependencies]
-openfhe = { git = "https://github.com/MachinaIO/openfhe-rs.git", branch = "refactor2" }
+openfhe = { git = "https://github.com/MachinaIO/openfhe-rs.git", branch = "feat/get_coeffs_to_bytes" }
 digest = "0.10"
 num-bigint = { version = "0.4", default-features = false }
 num-traits = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ test = []
 parallel = ["rayon"]
 
 [dependencies]
-openfhe = { git = "https://github.com/MachinaIO/openfhe-rs.git", branch = "feat/get_coeffs_to_bytes" }
+openfhe = { git = "https://github.com/MachinaIO/openfhe-rs.git", branch = "feat/get_coeffs_to_bytes_perf" }
 digest = "0.10"
 num-bigint = { version = "0.4", default-features = false }
 num-traits = "0.2"

--- a/src/poly/dcrt/poly.rs
+++ b/src/poly/dcrt/poly.rs
@@ -78,12 +78,9 @@ impl Poly for DCRTPoly {
     fn coeffs(&self) -> Vec<Self::Elem> {
         let poly_encoding = self.ptr_poly.GetCoefficientsBytes();
         let parsed_values = parse_coefficients_bytes(&poly_encoding);
-        let coeffs = &parsed_values[..parsed_values.len() - 1];
-        let modulus = &parsed_values[parsed_values.len() - 1];
-        // TODO: avoid cloning
-        parallel_iter!(coeffs)
-            .map(|s| FinRingElem::new(s.clone(), Arc::new(modulus.clone())))
-            .collect()
+        let coeffs = parsed_values.coefficients;
+        let modulus = parsed_values.modulus;
+        parallel_iter!(coeffs).map(|s| FinRingElem::new(s, Arc::new(modulus.clone()))).collect()
     }
 
     fn from_coeffs(params: &Self::Params, coeffs: &[Self::Elem]) -> Self {


### PR DESCRIPTION
Support to the new method `GetCoefficientsBytes` added on `openfhe-rs` -> https://github.com/MachinaIO/openfhe-rs/pull/1 .

Results show neglible differences in runtime and memory consumption between main and `feat/coeffs`