### PR TITLE
chore: obf clean

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ test = []
 parallel = ["rayon"]
 
 [dependencies]
-openfhe = { git = "https://github.com/MachinaIO/openfhe-rs.git", branch = "feat/preimage_to_disk" }
+openfhe = { git = "https://github.com/MachinaIO/openfhe-rs.git" }
 digest = "0.10"
 num-bigint = { version = "0.4", default-features = false }
 num-traits = "0.2"

--- a/justfile
+++ b/justfile
@@ -22,7 +22,7 @@ test:
    cargo test -r --features="parallel"
 
 test-io:
-   cargo test -r --test test_io --no-default-features --features parallel
+   cargo test -r --test test_io_dummy_param --no-default-features --features parallel
 
 # Run the entire CI pipeline including format, clippy, docs, and test checks
 ci: format clippy docs test test-io

--- a/src/bgg/circuit/mod.rs
+++ b/src/bgg/circuit/mod.rs
@@ -193,7 +193,7 @@ impl PolyCircuit {
     }
 
     /// Evaluate [`PolyCircuit`]
-    pub fn eval<E: Evaluable>(&self, params: &E::Params, one: E, inputs: &[E]) -> Vec<E> {
+    pub fn eval<E: Evaluable>(&self, params: &E::Params, one: &E, inputs: &[E]) -> Vec<E> {
         #[cfg(debug_assertions)]
         {
             assert_eq!(self.num_input(), inputs.len());
@@ -207,7 +207,7 @@ impl PolyCircuit {
         }
         let output_gates = self.output_ids.iter().map(|id| self.gates[id].clone()).collect_vec();
         for gate in output_gates.iter() {
-            self.eval_poly_gate(params, &one, &mut wires, gate);
+            self.eval_poly_gate(params, one, &mut wires, gate);
         }
         self.output_ids
             .iter()
@@ -275,7 +275,7 @@ impl PolyCircuit {
                             wires.get(id).expect("wire value not exist for target key").clone()
                         })
                         .collect_vec();
-                    let outputs = sub_circuit.eval(params, one.clone(), &inputs);
+                    let outputs = sub_circuit.eval(params, one, &inputs);
                     let first_output_wire = gate.gate_id - output_id;
                     for (idx, output_wire) in outputs.into_iter().enumerate() {
                         wires.insert(first_output_wire + idx, output_wire);
@@ -320,7 +320,7 @@ mod tests {
 
         // Evaluate the circuit
         let result =
-            circuit.eval(&params, DCRTPoly::const_one(&params), &[poly1.clone(), poly2.clone()]);
+            circuit.eval(&params, &DCRTPoly::const_one(&params), &[poly1.clone(), poly2.clone()]);
 
         // Expected result: poly1 + poly2
         let expected = poly1 + poly2;
@@ -347,7 +347,7 @@ mod tests {
 
         // Evaluate the circuit
         let result =
-            circuit.eval(&params, DCRTPoly::const_one(&params), &[poly1.clone(), poly2.clone()]);
+            circuit.eval(&params, &DCRTPoly::const_one(&params), &[poly1.clone(), poly2.clone()]);
 
         // Expected result: poly1 - poly2
         let expected = poly1 - poly2;
@@ -374,7 +374,7 @@ mod tests {
 
         // Evaluate the circuit
         let result =
-            circuit.eval(&params, DCRTPoly::const_one(&params), &[poly1.clone(), poly2.clone()]);
+            circuit.eval(&params, &DCRTPoly::const_one(&params), &[poly1.clone(), poly2.clone()]);
 
         // Expected result: poly1 * poly2
         let expected = poly1 * poly2;
@@ -404,7 +404,7 @@ mod tests {
 
         // Evaluate the circuit with any input (it won't be used)
         let dummy_input = create_random_poly(&params);
-        let result = circuit.eval(&params, DCRTPoly::const_one(&params), &[dummy_input]);
+        let result = circuit.eval(&params, &DCRTPoly::const_one(&params), &[dummy_input]);
 
         // Verify the result
         assert_eq!(result.len(), 1);
@@ -465,7 +465,7 @@ mod tests {
         // Evaluate the circuit
         let result = circuit.eval(
             &params,
-            DCRTPoly::const_one(&params),
+            &DCRTPoly::const_one(&params),
             &[poly1.clone(), poly2.clone(), poly3.clone()],
         );
 
@@ -503,7 +503,7 @@ mod tests {
 
         // Evaluate the circuit
         let result =
-            circuit.eval(&params, DCRTPoly::const_one(&params), &[poly1.clone(), poly2.clone()]);
+            circuit.eval(&params, &DCRTPoly::const_one(&params), &[poly1.clone(), poly2.clone()]);
 
         // Expected results
         let expected_add = poly1.clone() + poly2.clone();
@@ -557,7 +557,7 @@ mod tests {
         // Evaluate the circuit
         let result = circuit.eval(
             &params,
-            DCRTPoly::const_one(&params),
+            &DCRTPoly::const_one(&params),
             &[poly1.clone(), poly2.clone(), poly3.clone(), poly4.clone()],
         );
 
@@ -581,7 +581,7 @@ mod tests {
         let poly1 = create_bit_random_poly(&params);
         let poly2 = create_bit_random_poly(&params);
         let result =
-            circuit.eval(&params, DCRTPoly::const_one(&params), &[poly1.clone(), poly2.clone()]);
+            circuit.eval(&params, &DCRTPoly::const_one(&params), &[poly1.clone(), poly2.clone()]);
         let expected = poly1.clone() * poly2;
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].coeffs(), expected.coeffs());
@@ -595,7 +595,7 @@ mod tests {
         let not_result = circuit.not_gate(inputs[0]);
         circuit.output(vec![not_result]);
         let poly1 = create_bit_random_poly(&params);
-        let result = circuit.eval(&params, DCRTPoly::const_one(&params), &[poly1.clone()]);
+        let result = circuit.eval(&params, &DCRTPoly::const_one(&params), &[poly1.clone()]);
         let expected = DCRTPoly::const_one(&params) - poly1.clone();
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].coeffs(), expected.coeffs());
@@ -611,7 +611,7 @@ mod tests {
         let poly1 = create_bit_random_poly(&params);
         let poly2 = create_bit_random_poly(&params);
         let result =
-            circuit.eval(&params, DCRTPoly::const_one(&params), &[poly1.clone(), poly2.clone()]);
+            circuit.eval(&params, &DCRTPoly::const_one(&params), &[poly1.clone(), poly2.clone()]);
         let expected = (poly1.clone() + poly2.clone()) - (poly1 * poly2);
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].coeffs(), expected.coeffs());
@@ -627,7 +627,7 @@ mod tests {
         let poly1 = create_bit_random_poly(&params);
         let poly2 = create_bit_random_poly(&params);
         let result =
-            circuit.eval(&params, DCRTPoly::const_one(&params), &[poly1.clone(), poly2.clone()]);
+            circuit.eval(&params, &DCRTPoly::const_one(&params), &[poly1.clone(), poly2.clone()]);
         let expected = DCRTPoly::const_one(&params) - (poly1 * poly2);
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].coeffs(), expected.coeffs());
@@ -643,7 +643,7 @@ mod tests {
         let poly1 = create_bit_random_poly(&params);
         let poly2 = create_bit_random_poly(&params);
         let result =
-            circuit.eval(&params, DCRTPoly::const_one(&params), &[poly1.clone(), poly2.clone()]);
+            circuit.eval(&params, &DCRTPoly::const_one(&params), &[poly1.clone(), poly2.clone()]);
         let expected =
             DCRTPoly::const_one(&params) - ((poly1.clone() + poly2.clone()) - (poly1 * poly2));
         assert_eq!(result.len(), 1);
@@ -660,7 +660,7 @@ mod tests {
         let poly1 = create_bit_random_poly(&params);
         let poly2 = create_bit_random_poly(&params);
         let result =
-            circuit.eval(&params, DCRTPoly::const_one(&params), &[poly1.clone(), poly2.clone()]);
+            circuit.eval(&params, &DCRTPoly::const_one(&params), &[poly1.clone(), poly2.clone()]);
         let expected = (poly1.clone() + poly2.clone()) -
             (DCRTPoly::from_const(&params, &FinRingElem::new(2, params.modulus())) *
                 poly1 *
@@ -679,7 +679,7 @@ mod tests {
         let poly1 = create_bit_random_poly(&params);
         let poly2 = create_bit_random_poly(&params);
         let result =
-            circuit.eval(&params, DCRTPoly::const_one(&params), &[poly1.clone(), poly2.clone()]);
+            circuit.eval(&params, &DCRTPoly::const_one(&params), &[poly1.clone(), poly2.clone()]);
         let expected = DCRTPoly::const_one(&params) -
             ((poly1.clone() + poly2.clone()) -
                 (DCRTPoly::from_const(&params, &FinRingElem::new(2, params.modulus())) *
@@ -728,7 +728,7 @@ mod tests {
 
         // concatenate decomposed_c0 and decomposed_c1 and k
         let input = [c0_bits, c1_bits, vec![k.clone()]].concat();
-        let result = circuit.eval(&params, DCRTPoly::const_one(&params), &input);
+        let result = circuit.eval(&params, &DCRTPoly::const_one(&params), &input);
 
         assert_eq!(result.len(), params.modulus_bits() * 2);
 
@@ -792,7 +792,7 @@ mod tests {
         // Evaluate the main circuit
         let result = main_circuit.eval(
             &params,
-            DCRTPoly::const_one(&params),
+            &DCRTPoly::const_one(&params),
             &[poly1.clone(), poly2.clone()],
         );
 
@@ -854,7 +854,7 @@ mod tests {
         // Evaluate the main circuit
         let result = main_circuit.eval(
             &params,
-            DCRTPoly::const_one(&params),
+            &DCRTPoly::const_one(&params),
             &[poly1.clone(), poly2.clone(), poly3.clone()],
         );
 
@@ -881,7 +881,7 @@ mod tests {
 
         // Evaluate the circuit with any input (it won't be used)
         let dummy_input = create_random_poly(&params);
-        let result = circuit.eval(&params, DCRTPoly::const_one(&params), &[dummy_input]);
+        let result = circuit.eval(&params, &DCRTPoly::const_one(&params), &[dummy_input]);
 
         // Expected result: 0
         let expected = DCRTPoly::const_zero(&params);
@@ -905,7 +905,7 @@ mod tests {
 
         // Evaluate the circuit with any input (it won't be used)
         let dummy_input = create_random_poly(&params);
-        let result = circuit.eval(&params, DCRTPoly::const_one(&params), &[dummy_input]);
+        let result = circuit.eval(&params, &DCRTPoly::const_one(&params), &[dummy_input]);
 
         // Expected result: 1
         let expected = DCRTPoly::const_one(&params);
@@ -929,7 +929,7 @@ mod tests {
 
         // Evaluate the circuit with any input (it won't be used)
         let dummy_input = create_random_poly(&params);
-        let result = circuit.eval(&params, DCRTPoly::const_one(&params), &[dummy_input]);
+        let result = circuit.eval(&params, &DCRTPoly::const_one(&params), &[dummy_input]);
 
         // Expected result: -1
         // We can compute -1 as 0 - 1

--- a/src/bgg/circuit/utils.rs
+++ b/src/bgg/circuit/utils.rs
@@ -101,7 +101,7 @@ mod tests {
 
         // Evaluate the public circuit to get its outputs
         let pub_circuit_outputs =
-            public_circuit_for_eval.eval(&params, DCRTPoly::const_one(&params), &pub_polys);
+            public_circuit_for_eval.eval(&params, &DCRTPoly::const_one(&params), &pub_polys);
 
         // Verify that the public circuit outputs are as expected
         let expected_out1 = pub_polys[0].clone() + pub_polys[1].clone(); // add_gate(pub_inputs[0], pub_inputs[1])
@@ -138,7 +138,7 @@ mod tests {
 
         // Evaluate the inner product circuit
         let all_inputs = [pub_polys, priv_polys].concat();
-        let result = ip_circuit.eval(&params, DCRTPoly::const_one(&params), &all_inputs);
+        let result = ip_circuit.eval(&params, &DCRTPoly::const_one(&params), &all_inputs);
 
         // Verify the results
         assert_eq!(result.len(), 2);

--- a/src/bgg/encoding.rs
+++ b/src/bgg/encoding.rs
@@ -168,7 +168,7 @@ mod tests {
         circuit.output(vec![add_gate]);
 
         // Evaluate the circuit
-        let result = circuit.eval(&params, enc_one.clone(), &[enc1.clone(), enc2.clone()]);
+        let result = circuit.eval(&params, &enc_one.clone(), &[enc1.clone(), enc2.clone()]);
 
         // Expected result
         let expected = enc1.clone() + enc2.clone();
@@ -218,7 +218,7 @@ mod tests {
         circuit.output(vec![sub_gate]);
 
         // Evaluate the circuit
-        let result = circuit.eval(&params, enc_one.clone(), &[enc1.clone(), enc2.clone()]);
+        let result = circuit.eval(&params, &enc_one, &[enc1.clone(), enc2.clone()]);
 
         // Expected result
         let expected = enc1.clone() - enc2.clone();
@@ -268,7 +268,7 @@ mod tests {
         circuit.output(vec![mul_gate]);
 
         // Evaluate the circuit
-        let result = circuit.eval(&params, enc_one.clone(), &[enc1.clone(), enc2.clone()]);
+        let result = circuit.eval(&params, &enc_one, &[enc1.clone(), enc2.clone()]);
 
         // Expected result
         let expected = enc1.clone() * enc2.clone();
@@ -332,8 +332,7 @@ mod tests {
         circuit.output(vec![sub_gate]);
 
         // Evaluate the circuit
-        let result =
-            circuit.eval(&params, enc_one.clone(), &[enc1.clone(), enc2.clone(), enc3.clone()]);
+        let result = circuit.eval(&params, &enc_one, &[enc1.clone(), enc2.clone(), enc3.clone()]);
 
         // Expected result: ((enc1 + enc2)^2) - enc3
         let expected =
@@ -413,7 +412,7 @@ mod tests {
         // Evaluate the circuit
         let result = circuit.eval(
             &params,
-            enc_one.clone(),
+            &enc_one,
             &[enc1.clone(), enc2.clone(), enc3.clone(), enc4.clone()],
         );
 
@@ -498,7 +497,7 @@ mod tests {
         main_circuit.output(vec![final_gate]);
 
         // Evaluate the main circuit
-        let result = main_circuit.eval(&params, enc_one, &[enc1.clone(), enc2.clone()]);
+        let result = main_circuit.eval(&params, &enc_one, &[enc1.clone(), enc2.clone()]);
 
         // Expected result: (enc1 + enc2) - (enc1 * enc2)
         let expected = (enc1.clone() + enc2.clone()) - (enc1.clone() * enc2.clone());
@@ -586,7 +585,7 @@ mod tests {
 
         // Evaluate the main circuit
         let result =
-            main_circuit.eval(&params, enc_one, &[enc1.clone(), enc2.clone(), enc3.clone()]);
+            main_circuit.eval(&params, &enc_one, &[enc1.clone(), enc2.clone(), enc3.clone()]);
 
         // Expected result: ((enc1 * enc2) + enc3)^2
         let expected = ((enc1.clone() * enc2.clone()) + enc3.clone()) *

--- a/src/bgg/norm_simulator.rs
+++ b/src/bgg/norm_simulator.rs
@@ -21,7 +21,7 @@ impl PolyCircuit {
             ));
             remaining_inputs -= num_bits;
         }
-        let outputs = self.eval(&(), one, &inputs);
+        let outputs = self.eval(&(), &one, &inputs);
         NormBounds::from_norm_simulators(&outputs)
     }
 }

--- a/src/bgg/public_key.rs
+++ b/src/bgg/public_key.rs
@@ -120,7 +120,7 @@ mod tests {
         circuit.output(vec![add_gate]);
 
         // Evaluate the circuit
-        let result = circuit.eval(&params, pk_one, &[pk1.clone(), pk2.clone()]);
+        let result = circuit.eval(&params, &pk_one, &[pk1.clone(), pk2.clone()]);
 
         // Expected result
         let expected = pk1.clone() + pk2.clone();
@@ -160,7 +160,7 @@ mod tests {
         circuit.output(vec![sub_gate]);
 
         // Evaluate the circuit
-        let result = circuit.eval(&params, pk_one, &[pk1.clone(), pk2.clone()]);
+        let result = circuit.eval(&params, &pk_one, &[pk1.clone(), pk2.clone()]);
 
         // Expected result
         let expected = pk1.clone() - pk2.clone();
@@ -200,7 +200,7 @@ mod tests {
         circuit.output(vec![mul_gate]);
 
         // Evaluate the circuit
-        let result = circuit.eval(&params, pk_one, &[pk1.clone(), pk2.clone()]);
+        let result = circuit.eval(&params, &pk_one, &[pk1.clone(), pk2.clone()]);
 
         // Expected result
         let expected = pk1.clone() * pk2.clone();
@@ -250,7 +250,7 @@ mod tests {
         circuit.output(vec![sub_gate]);
 
         // Evaluate the circuit
-        let result = circuit.eval(&params, pk_one, &[pk1.clone(), pk2.clone(), pk3.clone()]);
+        let result = circuit.eval(&params, &pk_one, &[pk1.clone(), pk2.clone(), pk3.clone()]);
 
         // Expected result: ((pk1 + pk2)-2) - pk3
         let expected = ((pk1.clone() + pk2.clone()) * (pk1.clone() + pk2.clone())) - pk3.clone();
@@ -313,7 +313,7 @@ mod tests {
 
         // Evaluate the circuit
         let result =
-            circuit.eval(&params, pk_one, &[pk1.clone(), pk2.clone(), pk3.clone(), pk4.clone()]);
+            circuit.eval(&params, &pk_one, &[pk1.clone(), pk2.clone(), pk3.clone(), pk4.clone()]);
 
         // Expected result: (((pk1 + pk2) * (pk3 * pk4)) + (pk1 - pk3))^2
         let sum1 = pk1.clone() + pk2.clone();
@@ -386,7 +386,7 @@ mod tests {
         main_circuit.output(vec![final_gate]);
 
         // Evaluate the main circuit
-        let result = main_circuit.eval(&params, pk_one, &[pk1.clone(), pk2.clone()]);
+        let result = main_circuit.eval(&params, &pk_one, &[pk1.clone(), pk2.clone()]);
 
         // Expected result: (pk1 + pk2) - (pk1 * pk2)
         let expected = (pk1.clone() + pk2.clone()) - (pk1.clone() * pk2.clone());
@@ -459,7 +459,7 @@ mod tests {
         main_circuit.output(vec![square_gate]);
 
         // Evaluate the main circuit
-        let result = main_circuit.eval(&params, pk_one, &[pk1.clone(), pk2.clone(), pk3.clone()]);
+        let result = main_circuit.eval(&params, &pk_one, &[pk1.clone(), pk2.clone(), pk3.clone()]);
 
         // Expected result: ((pk1 * pk2) + pk3)^2
         let expected = ((pk1.clone() * pk2.clone()) + pk3.clone()) *

--- a/src/bgg/sampler.rs
+++ b/src/bgg/sampler.rs
@@ -24,7 +24,6 @@ pub struct BGGPublicKeySampler<K: AsRef<[u8]>, S: PolyHashSampler<K>> {
 impl<K: AsRef<[u8]>, S> BGGPublicKeySampler<K, S>
 where
     S: PolyHashSampler<K>,
-    <S as PolyHashSampler<K>>::M: Send + Sync,
 {
     /// Create a new public key sampler
     /// # Arguments
@@ -88,8 +87,6 @@ pub struct BGGEncodingSampler<S: PolyUniformSampler> {
 impl<S> BGGEncodingSampler<S>
 where
     S: PolyUniformSampler,
-    <S as PolyUniformSampler>::M: Send + Sync,
-    <<S as PolyUniformSampler>::M as PolyMatrix>::P: Send + Sync,
 {
     /// Create a new encoding sampler
     /// # Arguments

--- a/src/io/eval.rs
+++ b/src/io/eval.rs
@@ -181,7 +181,7 @@ where
         let last_input_encodings = encodings.last().unwrap();
         let output_encodings = final_circuit.eval::<BggEncoding<M>>(
             params.as_ref(),
-            last_input_encodings[0].clone(),
+            &last_input_encodings[0],
             &last_input_encodings[1..],
         );
         let output_encoding_ints = output_encodings

--- a/src/io/obf.rs
+++ b/src/io/obf.rs
@@ -188,6 +188,10 @@ where
             );
             log_mem("Computed n_preimage_bit");
 
+            if bit != 0 {
+                coeffs[inserted_coeff_index] = <M::P as Poly>::Elem::one(&params.modulus())
+            };
+
             k_preimages[idx][bit] = {
                 let inserted_poly_gadget = {
                     let gadget_d_plus_1 = M::gadget_matrix(&params, d + 1);
@@ -205,9 +209,7 @@ where
                 let k_target = {
                     let rg = &public_data.rgs[bit];
                     let top = lhs.mul_tensor_identity_decompose(rg, 1 + packed_input_size);
-                    if bit != 0 {
-                        coeffs[inserted_coeff_index] = <M::P as Poly>::Elem::one(&params.modulus())
-                    };
+
                     let bottom =
                         pub_key_idx[0].concat_matrix(&pub_key_idx[1..]) - &inserted_poly_gadget;
                     top.concat_rows(&[&bottom])

--- a/src/io/obf.rs
+++ b/src/io/obf.rs
@@ -39,7 +39,6 @@ where
     let hash_key = rng.random::<[u8; 32]>();
     sampler_hash.set_key(hash_key);
     let sampler_uniform = Arc::new(sampler_uniform);
-    let sampler_trapdoor = Arc::new(sampler_trapdoor);
     let bgg_pubkey_sampler = BGGPublicKeySampler::new(Arc::new(sampler_hash), d);
     let public_data = PublicSampledData::sample(&obf_params, &bgg_pubkey_sampler);
     log_mem("Sampled public data");
@@ -57,8 +56,7 @@ where
     let params = Arc::new(obf_params.params);
     let packed_input_size = public_data.packed_input_size;
     let packed_output_size = public_data.packed_output_size;
-    let s_bars =
-        sampler_uniform.sample_uniform(&params, 1, d, DistType::BitDist).get_row(0).clone();
+    let s_bars = sampler_uniform.sample_uniform(&params, 1, d, DistType::BitDist).get_row(0);
     log_mem("Sampled s_bars");
     let bgg_encode_sampler = BGGEncodingSampler::new(
         params.as_ref(),
@@ -86,9 +84,9 @@ where
     let enc_hardcoded_key_polys = enc_hardcoded_key.get_column_matrix_decompose(0).get_column(0);
     log_mem("Sampled enc_hardcoded_key_polys");
 
-    let t_bar = t_bar_matrix.entry(0, 0).clone();
+    let t_bar = t_bar_matrix.entry(0, 0);
     #[cfg(feature = "test")]
-    let hardcoded_key = hardcoded_key_matrix.entry(0, 0).clone();
+    let hardcoded_key = hardcoded_key_matrix.entry(0, 0);
 
     let mut plaintexts = (0..obf_params.input_size.div_ceil(dim))
         .map(|_| M::P::const_zero(params.as_ref()))

--- a/src/io/obf.rs
+++ b/src/io/obf.rs
@@ -236,7 +236,7 @@ where
     let final_preimage_target = {
         let one = pub_key_cur[0].clone();
         let input = &pub_key_cur[1..];
-        let eval_outputs = final_circuit.eval(params.as_ref(), one, input);
+        let eval_outputs = final_circuit.eval(params.as_ref(), &one, input);
         assert_eq!(eval_outputs.len(), log_q * packed_output_size);
         let output_ints = eval_outputs
             .chunks(log_q)

--- a/src/io/utils.rs
+++ b/src/io/utils.rs
@@ -208,7 +208,7 @@ mod test {
         let one = DCRTPoly::const_one(&params);
         let mut inputs = vec![one.clone()];
         inputs.push(t_bar.entry(0, 0).clone());
-        let circuit_outputs = final_circuit.eval(&params, one, &inputs);
+        let circuit_outputs = final_circuit.eval(&params, &one, &inputs);
         // 9. Extract the hardcoded key bits
         let hardcoded_key_bits = hardcoded_key
             .entry(0, 0)

--- a/src/io/utils.rs
+++ b/src/io/utils.rs
@@ -26,7 +26,6 @@ pub fn sample_public_key_by_idx<K: AsRef<[u8]>, S>(
 ) -> Vec<BggPublicKey<<S as PolyHashSampler<K>>::M>>
 where
     S: PolyHashSampler<K>,
-    <S as PolyHashSampler<K>>::M: Send + Sync,
 {
     sampler.sample(
         params,

--- a/src/poly/sampler.rs
+++ b/src/poly/sampler.rs
@@ -50,13 +50,14 @@ pub trait PolyUniformSampler {
 
 pub trait PolyTrapdoorSampler: Send + Sync {
     type M: PolyMatrix;
-    type Trapdoor: Send + Sync;
+    type Trapdoor;
 
     fn trapdoor(
         &self,
         params: &<<Self::M as PolyMatrix>::P as Poly>::Params,
         size: usize,
     ) -> (Self::Trapdoor, Self::M);
+
     fn preimage(
         &self,
         params: &<<Self::M as PolyMatrix>::P as Poly>::Params,
@@ -64,6 +65,7 @@ pub trait PolyTrapdoorSampler: Send + Sync {
         public_matrix: &Self::M,
         target: &Self::M,
     ) -> Self::M;
+
     fn process_preimage_block(
         &self,
         params: &<<Self::M as PolyMatrix>::P as Poly>::Params,

--- a/src/poly/sampler.rs
+++ b/src/poly/sampler.rs
@@ -48,7 +48,7 @@ pub trait PolyUniformSampler {
     ) -> Self::M;
 }
 
-pub trait PolyTrapdoorSampler: Send + Sync {
+pub trait PolyTrapdoorSampler {
     type M: PolyMatrix;
     type Trapdoor;
 

--- a/src/poly/sampler.rs
+++ b/src/poly/sampler.rs
@@ -52,8 +52,8 @@ pub trait PolyUniformSampler {
 
 pub trait PolyTrapdoorSampler {
     type M: PolyMatrix;
-    type Trapdoor: Send + Sync;
-    type MatrixPtr: Send + Sync;
+    type Trapdoor;
+    type MatrixPtr;
 
     fn trapdoor(
         &self,


### PR DESCRIPTION
remove unnecessary clone, define logic scope strictly on obfuscation

after (trivaial with https://github.com/MachinaIO/diamond-io/pull/56#issuecomment-2757207516)
```
2025-03-27T08:52:39.319165Z  INFO test_io_dummy_param::test: Time to obfuscate: 79.830405417s
2025-03-27T08:53:06.390972Z  INFO test_io_dummy_param::test: [false, false, false, true]
2025-03-27T08:53:06.390982Z  INFO test_io_dummy_param::test: Time for evaluation: 27.071620333s
2025-03-27T08:53:06.390984Z  INFO test_io_dummy_param::test: Total time: 106.90202575s
test test::test_io_just_mul_enc_and_bit ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 106.90s

Raw logs saved to logs/test_logs_20250327_175114.txt

===== COMBINED MEMORY USAGE =====

Step Description                                                       Physical Memory Virtual Memory  Physical Change % Change   Virtual Change  % Change  
------------------------------------------------------------------------------------------------------------------------------------------------------
Sampled public data                                                    8.59 MB         391.34 GB       0.0 B           0.00%      0.0 B           0.00%
Sampled pub key init                                                   10.17 MB        391.47 GB       1.58 MB         18.36%      136.00 MB       0.03%
Sampled s_bars                                                         10.17 MB        391.47 GB       0.0 B           0.00%      0.0 B           0.00%
Sampled t_bar_matrix                                                   10.17 MB        391.47 GB       0.0 B           0.00%      0.0 B           0.00%
Sampled hardcoded_key_matrix                                           10.17 MB        391.47 GB       0.0 B           0.00%      0.0 B           0.00%
Sampled enc_hardcoded_key_polys                                        10.17 MB        391.47 GB       0.0 B           0.00%      0.0 B           0.00%
Sampled initial encodings                                              10.89 MB        391.47 GB       736.00 KB       7.07%      0.0 B           0.00%
b star trapdoor init sampled                                           18.77 MB        391.51 GB       7.88 MB         72.31%      36.12 MB        0.01%
Computed p_init                                                        18.94 MB        391.51 GB       176.00 KB       0.92%      0.0 B           0.00%
Computed u_0, u_1, u_star                                              18.94 MB        391.51 GB       0.0 B           0.00%      0.0 B           0.00%
Sampled b_star trapdoor for idx                                        24.97 MB        391.51 GB       6.03 MB         31.85%      2.00 MB         0.00%
Sampled pub key idx                                                    25.64 MB        391.64 GB       688.00 KB       2.69%      128.00 MB       0.03%
Sampled b_star trapdoor for idx                                        25.64 MB        391.64 GB       0.0 B           0.00%      0.0 B           0.00%
Sampled b trapdoor for idx and bit                                     27.81 MB        391.64 GB       2.17 MB         8.47%      2.00 MB         0.00%
Collected preimages paths                                              79.30 MB        393.37 GB       51.48 MB        185.11%      1.73 GB         0.44%
Computed m_preimage_bit                                                79.30 MB        393.37 GB       0.0 B           0.00%      0.0 B           0.00%
Collected preimages paths                                              82.41 MB        393.37 GB       3.11 MB         3.92%      1.00 MB         0.00%
Computed n_preimage_bit                                                82.41 MB        393.37 GB       0.0 B           0.00%      0.0 B           0.00%
Collected preimages paths                                              87.05 MB        393.37 GB       4.64 MB         5.63%      3.00 MB         0.00%
Computed k_preimage_bit                                                87.05 MB        393.37 GB       0.0 B           0.00%      0.0 B           0.00%
Sampled b trapdoor for idx and bit                                     87.05 MB        393.37 GB       0.0 B           0.00%      0.0 B           0.00%
Collected preimages paths                                              88.14 MB        393.37 GB       1.09 MB         1.26%      0.0 B           0.00%
Computed m_preimage_bit                                                88.14 MB        393.37 GB       0.0 B           0.00%      0.0 B           0.00%
Collected preimages paths                                              88.97 MB        393.37 GB       848.00 KB       0.94%      16.00 KB        0.00%
Computed n_preimage_bit                                                88.97 MB        393.37 GB       0.0 B           0.00%      0.0 B           0.00%
Collected preimages paths                                              91.09 MB        393.37 GB       2.12 MB         2.39%      1.00 MB         0.00%
Computed k_preimage_bit                                                91.09 MB        393.37 GB       0.0 B           0.00%      0.0 B           0.00%
Computed final_preimage_target                                         88.73 MB        393.37 GB       -2473984.0 B    -2.59%      0.0 B           0.00%
Collected preimages paths                                              89.86 MB        393.37 GB       1.12 MB         1.27%      0.0 B           0.00%
Sampled final_preimage                                                 89.86 MB        393.37 GB       0.0 B           0.00%      0.0 B           0.00%
```