### PR TITLE
exp: chunk preimage loop

### DIFF
--- a/justfile
+++ b/justfile
@@ -22,7 +22,7 @@ test:
    cargo test -r --features="parallel"
 
 test-io:
-   cargo test -r --test test_io --no-default-features --features parallel
+   cargo test -r --test test_io_dummy_param --no-default-features --features parallel
 
 # Run the entire CI pipeline including format, clippy, docs, and test checks
 ci: format clippy docs test test-io

--- a/src/poly/dcrt/sampler/trapdoor.rs
+++ b/src/poly/dcrt/sampler/trapdoor.rs
@@ -123,9 +123,12 @@ impl PolyTrapdoorSampler for DCRTPolyTrapdoorSampler {
             "Target matrix should have the same number of rows as the public matrix"
         );
 
-        debug_mem("preimage before loop processing");
-        let chunk_size = 8;
+        let chunk_size = 20;
         let num_block = target_cols.div_ceil(size);
+        debug_mem(format!(
+            "preimage before loop processing with chunksize {}, out of {}",
+            chunk_size, num_block
+        ));
         let indices: Vec<_> = (0..num_block).collect();
         let preimages: Vec<_> = parallel_chunk_iter!(indices, chunk_size)
             .map(|chunk| {
@@ -135,8 +138,7 @@ impl PolyTrapdoorSampler for DCRTPolyTrapdoorSampler {
                         let start_col = i * size;
                         let end_col = (start_col + size).min(target_cols);
                         let target_block = target.slice(0, size, start_col, end_col);
-                        debug_mem(format!("preimage iter : start_col = {}", start_col));
-
+                        debug_mem(format!("preimage iter: start_col = {}", start_col));
                         self.process_preimage_block(params, trapdoor, public_matrix, &target_block)
                     })
                     .collect::<Vec<_>>()

--- a/src/poly/dcrt/sampler/trapdoor.rs
+++ b/src/poly/dcrt/sampler/trapdoor.rs
@@ -40,7 +40,7 @@ impl DCRTMatrixPtr {
         let mut target_matrix_ptr =
             MatrixGen(params.ring_dimension(), params.crt_depth(), params.crt_bits(), size, size);
 
-        debug_mem("target_matrix_ptr generated");
+        debug_mem("target_matrix_ptr MatrixGen");
 
         for i in 0..size {
             for j in 0..target_cols {
@@ -71,13 +71,16 @@ impl DCRTMatrixPtr {
     ) -> Self {
         let mut public_matrix_ptr = MatrixGen(n, size, k_res, nrow, ncol);
 
-        debug_mem("public_matrix_ptr generated");
+        debug_mem("public_matrix_ptr MatrixGen");
 
         for i in 0..nrow {
             for j in 0..ncol {
-                let entry = matrix.entry(i, j);
-                let poly = entry.get_poly();
-                SetMatrixElement(public_matrix_ptr.as_mut().unwrap(), i, j, poly);
+                SetMatrixElement(
+                    public_matrix_ptr.as_mut().unwrap(),
+                    i,
+                    j,
+                    matrix.entry(i, j).get_poly(),
+                );
             }
         }
 
@@ -94,9 +97,7 @@ impl DCRTMatrixPtr {
         for i in 0..nrow {
             let mut row = Vec::with_capacity(ncol);
             for j in 0..ncol {
-                let poly = GetMatrixElement(&self.ptr_matrix, i, j);
-                let dcrt_poly = DCRTPoly::new(poly);
-                row.push(dcrt_poly);
+                row.push(DCRTPoly::new(GetMatrixElement(&self.ptr_matrix, i, j)));
             }
             matrix_inner.push(row);
         }

--- a/src/poly/dcrt/sampler/trapdoor.rs
+++ b/src/poly/dcrt/sampler/trapdoor.rs
@@ -210,7 +210,7 @@ impl PolyTrapdoorSampler for DCRTPolyTrapdoorSampler {
         );
 
         // todo: real param and dummy param should have diff value
-        let chunk_size = 1;
+        let chunk_size = 20;
         let num_block = target_cols.div_ceil(size);
         let k = params.modulus_bits();
         debug_mem(format!(

--- a/src/poly/dcrt/sampler/trapdoor.rs
+++ b/src/poly/dcrt/sampler/trapdoor.rs
@@ -265,9 +265,9 @@ impl PolyTrapdoorSampler for DCRTPolyTrapdoorSampler {
         let k = params.modulus_bits();
         let target_cols = target_block.col_size();
 
-        debug_mem("Processing preimage block");
+        debug_mem(format!("Processing preimage block, target_cols={}, size={}", target_cols, size));
 
-        let target_matrix_ptr =
+        let target_matrix =
             DCRTMatrixPtr::new_target_matrix(target_block, params, size, target_cols);
 
         debug_mem("SetMatrixElement target_matrix_ptr completed");
@@ -278,7 +278,7 @@ impl PolyTrapdoorSampler for DCRTPolyTrapdoorSampler {
                 k as u32,
                 &public_matrix.ptr_matrix,
                 &trapdoor.ptr_trapdoor,
-                &target_matrix_ptr.ptr_matrix,
+                &target_matrix.ptr_matrix,
                 2_i64,
                 SIGMA,
             )
@@ -286,15 +286,16 @@ impl PolyTrapdoorSampler for DCRTPolyTrapdoorSampler {
         };
         debug_mem("DCRTSquareMatTrapdoorGaussSamp completed");
 
-        let full_preimage = preimage_matrix.to_dcry_poly_matrix(size * (k + 2), size, params);
+        let full_preimage_matrix =
+            preimage_matrix.to_dcry_poly_matrix(size * (k + 2), size, params);
 
-        debug_mem("full_preimage generated");
+        debug_mem("full_preimage_matrix generated");
 
         if target_cols < size {
-            debug_mem("Slicing full_preimage columns");
-            full_preimage.slice_columns(0, target_cols)
+            debug_mem("Slicing full_preimage_matrix columns");
+            full_preimage_matrix.slice_columns(0, target_cols)
         } else {
-            full_preimage
+            full_preimage_matrix
         }
     }
 }

--- a/src/poly/dcrt/sampler/trapdoor.rs
+++ b/src/poly/dcrt/sampler/trapdoor.rs
@@ -123,7 +123,8 @@ impl PolyTrapdoorSampler for DCRTPolyTrapdoorSampler {
             "Target matrix should have the same number of rows as the public matrix"
         );
 
-        let chunk_size = 20;
+        // todo: real param and dummy param should have diff value
+        let chunk_size = 80;
         let num_block = target_cols.div_ceil(size);
         debug_mem(format!(
             "preimage before loop processing with chunksize {}, out of {}",

--- a/src/poly/dcrt/sampler/trapdoor.rs
+++ b/src/poly/dcrt/sampler/trapdoor.rs
@@ -210,7 +210,7 @@ impl PolyTrapdoorSampler for DCRTPolyTrapdoorSampler {
         );
 
         // todo: real param and dummy param should have diff value
-        let chunk_size = 20;
+        let chunk_size = 100;
         let num_block = target_cols.div_ceil(size);
         let k = params.modulus_bits();
         debug_mem(format!(

--- a/src/poly/dcrt/sampler/trapdoor.rs
+++ b/src/poly/dcrt/sampler/trapdoor.rs
@@ -40,7 +40,7 @@ impl DCRTMatrixPtr {
         let mut target_matrix_ptr =
             MatrixGen(params.ring_dimension(), params.crt_depth(), params.crt_bits(), size, size);
 
-        debug_mem("target_matrix_ptr MatrixGen");
+        debug_mem(format!("target_matrix_ptr MatrixGen row={}, col={}", size, target_cols));
 
         for i in 0..size {
             for j in 0..target_cols {
@@ -71,7 +71,7 @@ impl DCRTMatrixPtr {
     ) -> Self {
         let mut public_matrix_ptr = MatrixGen(n, size, k_res, nrow, ncol);
 
-        debug_mem("public_matrix_ptr MatrixGen");
+        debug_mem(format!("public_matrix_ptr MatrixGen row={}, col={}", nrow, ncol));
 
         for i in 0..nrow {
             for j in 0..ncol {
@@ -101,7 +101,8 @@ impl DCRTMatrixPtr {
             }
             matrix_inner.push(row);
         }
-        debug_mem("GetMatrixElement completed");
+
+        debug_mem(format!("GetMatrixElement row={}, col={}", nrow, ncol));
         DCRTPolyMatrix::from_poly_vec(params, matrix_inner)
     }
 }

--- a/src/poly/sampler.rs
+++ b/src/poly/sampler.rs
@@ -51,6 +51,7 @@ pub trait PolyUniformSampler {
 pub trait PolyTrapdoorSampler: Send + Sync {
     type M: PolyMatrix;
     type Trapdoor: Send + Sync;
+    type MatrixPtr: Send + Sync;
 
     fn trapdoor(
         &self,
@@ -68,7 +69,8 @@ pub trait PolyTrapdoorSampler: Send + Sync {
         &self,
         params: &<<Self::M as PolyMatrix>::P as Poly>::Params,
         trapdoor: &Self::Trapdoor,
-        public_matrix: &Self::M,
+        public_matrix: &Self::MatrixPtr,
         target_block: &Self::M,
+        size: usize,
     ) -> Self::M;
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -117,6 +117,20 @@ macro_rules! parallel_iter {
 }
 
 #[macro_export]
+macro_rules! parallel_chunk_iter {
+    ($i: expr, $chunk_size: expr) => {{
+        let chunks: Vec<_> = $i.chunks($chunk_size).map(|c| c.to_vec()).collect();
+        #[cfg(not(feature = "parallel"))]
+        {
+            chunks.into_iter()
+        }
+        #[cfg(feature = "parallel")]
+        {
+            rayon::iter::IntoParallelIterator::into_par_iter(chunks)
+        }
+    }};
+}
+#[macro_export]
 macro_rules! join {
     ($a:expr, $b:expr $(,)?) => {{
         #[cfg(not(feature = "parallel"))]


### PR DESCRIPTION
## Description

try to parallelize in small unit as possible where peak memory can be bounded

## perf

for dummy param have 50mb ish memory advantage, but non parallel increase time consumption as correspondingly - but it only effect on obfuscation step

also this 50mb might seems trivial, but real param the peak consumption effects alot

before - with parallel every element
```

===== COMBINED MEMORY USAGE =====

Step Description                                                       Physical Memory Virtual Memory  Physical Change % Change   Virtual Change  % Change  
------------------------------------------------------------------------------------------------------------------------------------------------------
Sampled public data                                                    8.50 MB         391.33 GB       0.0 B           0.00%      0.0 B           0.00%
Sampled pub key init                                                   10.11 MB        391.47 GB       1.61 MB         18.93%      136.00 MB       0.03%
Sampled s_bars                                                         10.11 MB        391.47 GB       0.0 B           0.00%      0.0 B           0.00%
Sampled t_bar_matrix                                                   10.11 MB        391.47 GB       0.0 B           0.00%      0.0 B           0.00%
Sampled hardcoded_key_matrix                                           10.11 MB        391.47 GB       0.0 B           0.00%      0.0 B           0.00%
Sampled enc_hardcoded_key_polys                                        10.12 MB        391.47 GB       16.00 KB        0.15%      8.03 MB         0.00%
Sampled initial encodings                                              10.89 MB        391.47 GB       784.00 KB       7.56%      0.0 B           0.00%
b star trapdoor init sampled                                           18.42 MB        391.51 GB       7.53 MB         69.15%      36.12 MB        0.01%
Computed p_init                                                        18.62 MB        391.51 GB       208.00 KB       1.10%      0.0 B           0.00%
Computed u_0, u_1, u_star                                              18.62 MB        391.51 GB       0.0 B           0.00%      0.0 B           0.00%
Sampled b_star trapdoor for idx                                        23.12 MB        391.51 GB       4.50 MB         24.16%      1.00 MB         0.00%
Sampled pub key idx                                                    24.17 MB        391.63 GB       1.05 MB         4.53%      128.00 MB       0.03%
Sampled b_star trapdoor for idx                                        24.17 MB        391.63 GB       0.0 B           0.00%      0.0 B           0.00%
Sampled b trapdoor for idx and bit                                     27.78 MB        391.64 GB       3.61 MB         14.93%      11.00 MB        0.00%
Collected preimages                                                    103.56 MB       392.64 GB       75.78 MB        272.78%      1016.78 MB      0.25%
Computed m_preimage_bit                                                103.58 MB       392.64 GB       16.00 KB        0.02%      0.0 B           0.00%
Collected preimages                                                    142.98 MB       392.67 GB       39.41 MB        38.04%      35.02 MB        0.01%
Computed n_preimage_bit                                                142.98 MB       392.67 GB       0.0 B           0.00%      0.0 B           0.00%
Collected preimages                                                    186.75 MB       392.71 GB       43.77 MB        30.61%      41.00 MB        0.01%
Computed k_preimage_bit                                                186.75 MB       392.71 GB       0.0 B           0.00%      0.0 B           0.00%
Sampled b trapdoor for idx and bit                                     186.78 MB       392.71 GB       32.00 KB        0.02%      0.0 B           0.00%
Collected preimages                                                    218.95 MB       392.74 GB       32.17 MB        17.22%      32.02 MB        0.01%
Computed m_preimage_bit                                                218.95 MB       392.74 GB       0.0 B           0.00%      0.0 B           0.00%
Collected preimages                                                    245.62 MB       392.77 GB       26.67 MB        12.18%      24.00 MB        0.01%
Computed n_preimage_bit                                                245.62 MB       392.77 GB       0.0 B           0.00%      0.0 B           0.00%
Collected preimages                                                    294.56 MB       392.82 GB       48.94 MB        19.92%      50.00 MB        0.01%
Computed k_preimage_bit                                                294.56 MB       392.82 GB       0.0 B           0.00%      0.0 B           0.00%
Computed final_preimage_target                                         295.17 MB       392.81 GB       624.00 KB       0.21%      -1048576.0 B    -0.00%
Collected preimages                                                    295.17 MB       392.81 GB       0.0 B           0.00%      0.0 B           0.00%
Sampled final_preimage                                                 295.17 MB       392.81 GB       0.0 B           0.00%      0.0 B           0.00%

===== SUMMARY =====
Initial memory (physical/virtual): 8.50 MB / 391.33 GB
Final memory (physical/virtual): 295.17 MB / 392.81 GB
Peak memory (physical/virtual): 295.17 MB / 392.82 GB
Total increase (physical/virtual): 286.67 MB / 1.48 GB

2025-03-27T03:24:57.179890Z  INFO test_io_dummy_param::test: Time to obfuscate: 77.02023275s
2025-03-27T03:25:25.357265Z  INFO test_io_dummy_param::test: [false, false, false, true]
2025-03-27T03:25:25.357277Z  INFO test_io_dummy_param::test: Time for evaluation: 28.177009917s
2025-03-27T03:25:25.357279Z  INFO test_io_dummy_param::test: Total time: 105.197242667s
```

after - without parallel 

```
===== COMBINED MEMORY USAGE =====

Step Description                                                       Physical Memory Virtual Memory  Physical Change % Change   Virtual Change  % Change  
------------------------------------------------------------------------------------------------------------------------------------------------------
Sampled public data                                                    8.56 MB         391.35 GB       0.0 B           0.00%      0.0 B           0.00%
Sampled pub key init                                                   10.11 MB        391.47 GB       1.55 MB         18.07%      128.00 MB       0.03%
Sampled s_bars                                                         10.11 MB        391.47 GB       0.0 B           0.00%      0.0 B           0.00%
Sampled t_bar_matrix                                                   10.11 MB        391.47 GB       0.0 B           0.00%      0.0 B           0.00%
Sampled hardcoded_key_matrix                                           10.11 MB        391.47 GB       0.0 B           0.00%      0.0 B           0.00%
Sampled enc_hardcoded_key_polys                                        10.12 MB        391.48 GB       16.00 KB        0.15%      8.03 MB         0.00%
Sampled initial encodings                                              11.00 MB        391.48 GB       896.00 KB       8.64%      0.0 B           0.00%
b star trapdoor init sampled                                           18.36 MB        391.52 GB       7.36 MB         66.90%      35.12 MB        0.01%
Computed p_init                                                        18.53 MB        391.52 GB       176.00 KB       0.94%      0.0 B           0.00%
Computed u_0, u_1, u_star                                              18.53 MB        391.52 GB       0.0 B           0.00%      0.0 B           0.00%
Sampled b_star trapdoor for idx                                        22.83 MB        391.52 GB       4.30 MB         23.19%      3.00 MB         0.00%
Sampled pub key idx                                                    23.88 MB        391.64 GB       1.05 MB         4.59%      128.00 MB       0.03%
Sampled b_star trapdoor for idx                                        23.88 MB        391.64 GB       0.0 B           0.00%      0.0 B           0.00%
Sampled b trapdoor for idx and bit                                     27.66 MB        391.64 GB       3.78 MB         15.84%      2.00 MB         0.00%
Collected preimages                                                    65.80 MB        391.68 GB       38.14 MB        137.91%      33.03 MB        0.01%
Computed m_preimage_bit                                                65.95 MB        391.68 GB       160.00 KB       0.24%      0.0 B           0.00%
Collected preimages                                                    96.84 MB        391.71 GB       30.89 MB        46.84%      31.02 MB        0.01%
Computed n_preimage_bit                                                95.95 MB        391.71 GB       -933888.0 B     -0.92%      -1048576.0 B    -0.00%
Collected preimages                                                    140.52 MB       391.86 GB       44.56 MB        46.44%      156.44 MB       0.04%
Computed k_preimage_bit                                                140.59 MB       391.86 GB       80.00 KB        0.06%      0.0 B           0.00%
Sampled b trapdoor for idx and bit                                     141.28 MB       391.86 GB       704.00 KB       0.49%      0.0 B           0.00%
Collected preimages                                                    168.78 MB       391.89 GB       27.50 MB        19.46%      27.00 MB        0.01%
Computed m_preimage_bit                                                168.86 MB       391.89 GB       80.00 KB        0.05%      0.0 B           0.00%
Collected preimages                                                    197.95 MB       391.91 GB       29.09 MB        17.23%      28.02 MB        0.01%
Computed n_preimage_bit                                                198.08 MB       391.91 GB       128.00 KB       0.06%      0.0 B           0.00%
Collected preimages                                                    234.19 MB       391.95 GB       36.11 MB        18.23%      39.00 MB        0.01%
Computed k_preimage_bit                                                234.22 MB       391.95 GB       32.00 KB        0.01%      0.0 B           0.00%
Computed final_preimage_target                                         241.17 MB       392.33 GB       6.95 MB         2.97%      390.50 MB       0.10%
Collected preimages                                                    242.30 MB       392.33 GB       1.12 MB         0.47%      0.0 B           0.00%
Sampled final_preimage                                                 242.30 MB       392.33 GB       0.0 B           0.00%      0.0 B           0.00%

===== SUMMARY =====
Initial memory (physical/virtual): 8.56 MB / 391.35 GB
Final memory (physical/virtual): 242.30 MB / 392.33 GB
Peak memory (physical/virtual): 242.30 MB / 392.33 GB
Total increase (physical/virtual): 233.73 MB / 1008.16 MB

2025-03-27T03:21:49.986274Z  INFO test_io_dummy_param::test: Time to obfuscate: 257.375411084s
2025-03-27T03:22:16.286795Z  INFO test_io_dummy_param::test: [true, true, false, false]
2025-03-27T03:22:16.286803Z  INFO test_io_dummy_param::test: Time for evaluation: 26.300180291s
2025-03-27T03:22:16.286805Z  INFO test_io_dummy_param::test: Total time: 283.675591375s
```