### PR TITLE
feat: reuse public matrix for preimage

### DIFF
--- a/justfile
+++ b/justfile
@@ -22,7 +22,7 @@ test:
    cargo test -r --features="parallel"
 
 test-io:
-   cargo test -r --test test_io --no-default-features --features parallel
+   cargo test -r --test test_io_dummy_param --no-default-features --features parallel
 
 # Run the entire CI pipeline including format, clippy, docs, and test checks
 ci: format clippy docs test test-io

--- a/src/poly/dcrt/sampler/trapdoor.rs
+++ b/src/poly/dcrt/sampler/trapdoor.rs
@@ -123,9 +123,12 @@ impl PolyTrapdoorSampler for DCRTPolyTrapdoorSampler {
             "Target matrix should have the same number of rows as the public matrix"
         );
 
-        debug_mem("preimage before loop processing");
-        let chunk_size = 8;
+        let chunk_size = 20;
         let num_block = target_cols.div_ceil(size);
+        debug_mem(format!(
+            "preimage before loop processing with chunksize {}, out of {}",
+            chunk_size, num_block
+        ));
         let indices: Vec<_> = (0..num_block).collect();
         let preimages: Vec<_> = parallel_chunk_iter!(indices, chunk_size)
             .map(|chunk| {
@@ -135,8 +138,7 @@ impl PolyTrapdoorSampler for DCRTPolyTrapdoorSampler {
                         let start_col = i * size;
                         let end_col = (start_col + size).min(target_cols);
                         let target_block = target.slice(0, size, start_col, end_col);
-                        debug_mem(format!("preimage iter : start_col = {}", start_col));
-
+                        debug_mem(format!("preimage iter: start_col = {}", start_col));
                         self.process_preimage_block(params, trapdoor, public_matrix, &target_block)
                     })
                     .collect::<Vec<_>>()

--- a/src/poly/dcrt/sampler/trapdoor.rs
+++ b/src/poly/dcrt/sampler/trapdoor.rs
@@ -40,7 +40,7 @@ impl DCRTMatrixPtr {
         let mut target_matrix_ptr =
             MatrixGen(params.ring_dimension(), params.crt_depth(), params.crt_bits(), size, size);
 
-        debug_mem("target_matrix_ptr generated");
+        debug_mem("target_matrix_ptr MatrixGen");
 
         for i in 0..size {
             for j in 0..target_cols {
@@ -71,13 +71,16 @@ impl DCRTMatrixPtr {
     ) -> Self {
         let mut public_matrix_ptr = MatrixGen(n, size, k_res, nrow, ncol);
 
-        debug_mem("public_matrix_ptr generated");
+        debug_mem("public_matrix_ptr MatrixGen");
 
         for i in 0..nrow {
             for j in 0..ncol {
-                let entry = matrix.entry(i, j);
-                let poly = entry.get_poly();
-                SetMatrixElement(public_matrix_ptr.as_mut().unwrap(), i, j, poly);
+                SetMatrixElement(
+                    public_matrix_ptr.as_mut().unwrap(),
+                    i,
+                    j,
+                    matrix.entry(i, j).get_poly(),
+                );
             }
         }
 
@@ -94,9 +97,7 @@ impl DCRTMatrixPtr {
         for i in 0..nrow {
             let mut row = Vec::with_capacity(ncol);
             for j in 0..ncol {
-                let poly = GetMatrixElement(&self.ptr_matrix, i, j);
-                let dcrt_poly = DCRTPoly::new(poly);
-                row.push(dcrt_poly);
+                row.push(DCRTPoly::new(GetMatrixElement(&self.ptr_matrix, i, j)));
             }
             matrix_inner.push(row);
         }

--- a/src/poly/dcrt/sampler/trapdoor.rs
+++ b/src/poly/dcrt/sampler/trapdoor.rs
@@ -210,7 +210,7 @@ impl PolyTrapdoorSampler for DCRTPolyTrapdoorSampler {
         );
 
         // todo: real param and dummy param should have diff value
-        let chunk_size = 1;
+        let chunk_size = 20;
         let num_block = target_cols.div_ceil(size);
         let k = params.modulus_bits();
         debug_mem(format!(

--- a/src/poly/dcrt/sampler/trapdoor.rs
+++ b/src/poly/dcrt/sampler/trapdoor.rs
@@ -265,9 +265,9 @@ impl PolyTrapdoorSampler for DCRTPolyTrapdoorSampler {
         let k = params.modulus_bits();
         let target_cols = target_block.col_size();
 
-        debug_mem("Processing preimage block");
+        debug_mem(format!("Processing preimage block, target_cols={}, size={}", target_cols, size));
 
-        let target_matrix_ptr =
+        let target_matrix =
             DCRTMatrixPtr::new_target_matrix(target_block, params, size, target_cols);
 
         debug_mem("SetMatrixElement target_matrix_ptr completed");
@@ -278,7 +278,7 @@ impl PolyTrapdoorSampler for DCRTPolyTrapdoorSampler {
                 k as u32,
                 &public_matrix.ptr_matrix,
                 &trapdoor.ptr_trapdoor,
-                &target_matrix_ptr.ptr_matrix,
+                &target_matrix.ptr_matrix,
                 2_i64,
                 SIGMA,
             )
@@ -286,15 +286,16 @@ impl PolyTrapdoorSampler for DCRTPolyTrapdoorSampler {
         };
         debug_mem("DCRTSquareMatTrapdoorGaussSamp completed");
 
-        let full_preimage = preimage_matrix.to_dcry_poly_matrix(size * (k + 2), size, params);
+        let full_preimage_matrix =
+            preimage_matrix.to_dcry_poly_matrix(size * (k + 2), size, params);
 
-        debug_mem("full_preimage generated");
+        debug_mem("full_preimage_matrix generated");
 
         if target_cols < size {
-            debug_mem("Slicing full_preimage columns");
-            full_preimage.slice_columns(0, target_cols)
+            debug_mem("Slicing full_preimage_matrix columns");
+            full_preimage_matrix.slice_columns(0, target_cols)
         } else {
-            full_preimage
+            full_preimage_matrix
         }
     }
 }

--- a/src/poly/dcrt/sampler/trapdoor.rs
+++ b/src/poly/dcrt/sampler/trapdoor.rs
@@ -3,7 +3,7 @@ use rayon::prelude::*;
 use std::sync::Arc;
 
 use crate::{
-    parallel_chunk_iter, parallel_iter,
+    parallel_iter,
     poly::{
         dcrt::{DCRTPoly, DCRTPolyMatrix, DCRTPolyParams},
         sampler::PolyTrapdoorSampler,
@@ -224,12 +224,13 @@ impl PolyTrapdoorSampler for DCRTPolyTrapdoorSampler {
 
         debug_mem("SetMatrixElement public_matrix_ptr completed");
 
-        let preimages: Vec<_> = (0..num_block)
+        let preimages: Vec<_> = parallel_iter!(0..num_block)
             .map(|i| {
                 let start_col = i * size;
                 let end_col = (start_col + size).min(target_cols);
                 let target_block = target.slice(0, size, start_col, end_col);
-                debug_mem(format!("preimage iter: start_col = {}", start_col));
+                debug_mem(format!("preimage iter : start_col = {}", start_col));
+
                 self.process_preimage_block(params, trapdoor, &public_matrix, &target_block, size)
             })
             .collect();

--- a/src/poly/dcrt/sampler/trapdoor.rs
+++ b/src/poly/dcrt/sampler/trapdoor.rs
@@ -123,7 +123,8 @@ impl PolyTrapdoorSampler for DCRTPolyTrapdoorSampler {
             "Target matrix should have the same number of rows as the public matrix"
         );
 
-        let chunk_size = 20;
+        // todo: real param and dummy param should have diff value
+        let chunk_size = 80;
         let num_block = target_cols.div_ceil(size);
         debug_mem(format!(
             "preimage before loop processing with chunksize {}, out of {}",

--- a/src/poly/dcrt/sampler/trapdoor.rs
+++ b/src/poly/dcrt/sampler/trapdoor.rs
@@ -210,7 +210,7 @@ impl PolyTrapdoorSampler for DCRTPolyTrapdoorSampler {
         );
 
         // todo: real param and dummy param should have diff value
-        let chunk_size = 20;
+        let chunk_size = 100;
         let num_block = target_cols.div_ceil(size);
         let k = params.modulus_bits();
         debug_mem(format!(

--- a/src/poly/dcrt/sampler/trapdoor.rs
+++ b/src/poly/dcrt/sampler/trapdoor.rs
@@ -40,7 +40,7 @@ impl DCRTMatrixPtr {
         let mut target_matrix_ptr =
             MatrixGen(params.ring_dimension(), params.crt_depth(), params.crt_bits(), size, size);
 
-        debug_mem("target_matrix_ptr MatrixGen");
+        debug_mem(format!("target_matrix_ptr MatrixGen row={}, col={}", size, target_cols));
 
         for i in 0..size {
             for j in 0..target_cols {
@@ -71,7 +71,7 @@ impl DCRTMatrixPtr {
     ) -> Self {
         let mut public_matrix_ptr = MatrixGen(n, size, k_res, nrow, ncol);
 
-        debug_mem("public_matrix_ptr MatrixGen");
+        debug_mem(format!("public_matrix_ptr MatrixGen row={}, col={}", nrow, ncol));
 
         for i in 0..nrow {
             for j in 0..ncol {
@@ -101,7 +101,8 @@ impl DCRTMatrixPtr {
             }
             matrix_inner.push(row);
         }
-        debug_mem("GetMatrixElement completed");
+
+        debug_mem(format!("GetMatrixElement row={}, col={}", nrow, ncol));
         DCRTPolyMatrix::from_poly_vec(params, matrix_inner)
     }
 }

--- a/src/poly/sampler.rs
+++ b/src/poly/sampler.rs
@@ -51,6 +51,7 @@ pub trait PolyUniformSampler {
 pub trait PolyTrapdoorSampler: Send + Sync {
     type M: PolyMatrix;
     type Trapdoor: Send + Sync;
+    type MatrixPtr: Send + Sync;
 
     fn trapdoor(
         &self,
@@ -68,7 +69,8 @@ pub trait PolyTrapdoorSampler: Send + Sync {
         &self,
         params: &<<Self::M as PolyMatrix>::P as Poly>::Params,
         trapdoor: &Self::Trapdoor,
-        public_matrix: &Self::M,
+        public_matrix: &Self::MatrixPtr,
         target_block: &Self::M,
+        size: usize,
     ) -> Self::M;
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -117,20 +117,6 @@ macro_rules! parallel_iter {
 }
 
 #[macro_export]
-macro_rules! parallel_chunk_iter {
-    ($i: expr, $chunk_size: expr) => {{
-        let chunks: Vec<_> = $i.chunks($chunk_size).map(|c| c.to_vec()).collect();
-        #[cfg(not(feature = "parallel"))]
-        {
-            chunks.into_iter()
-        }
-        #[cfg(feature = "parallel")]
-        {
-            rayon::iter::IntoParallelIterator::into_par_iter(chunks)
-        }
-    }};
-}
-#[macro_export]
 macro_rules! join {
     ($a:expr, $b:expr $(,)?) => {{
         #[cfg(not(feature = "parallel"))]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -117,6 +117,20 @@ macro_rules! parallel_iter {
 }
 
 #[macro_export]
+macro_rules! parallel_chunk_iter {
+    ($i: expr, $chunk_size: expr) => {{
+        let chunks: Vec<_> = $i.chunks($chunk_size).map(|c| c.to_vec()).collect();
+        #[cfg(not(feature = "parallel"))]
+        {
+            chunks.into_iter()
+        }
+        #[cfg(feature = "parallel")]
+        {
+            rayon::iter::IntoParallelIterator::into_par_iter(chunks)
+        }
+    }};
+}
+#[macro_export]
 macro_rules! join {
     ($a:expr, $b:expr $(,)?) => {{
         #[cfg(not(feature = "parallel"))]


### PR DESCRIPTION
## Description

Don't duplicate public matrix generation per each loop of the preimage sample step.

## perf

It doesn't have a memory advantage, but it has slight time advantage + nonduplicating logic

But this advantage becomes huge, especially if we were to use mmap(because if then `SetElement` takes too long).

before
```
2025-03-27T03:24:57.179890Z  INFO test_io_dummy_param::test: Time to obfuscate: 77.02023275s
2025-03-27T03:25:25.357265Z  INFO test_io_dummy_param::test: [false, false, false, true]
2025-03-27T03:25:25.357277Z  INFO test_io_dummy_param::test: Time for evaluation: 28.177009917s
2025-03-27T03:25:25.357279Z  INFO test_io_dummy_param::test: Total time: 105.197242667s
```

after

```
2025-03-27T03:37:40.327227Z  INFO test_io_dummy_param::test: Time to obfuscate: 74.563497625s
2025-03-27T03:38:07.560632Z  INFO test_io_dummy_param::test: [true, true, false, false]
2025-03-27T03:38:07.560641Z  INFO test_io_dummy_param::test: Time for evaluation: 27.233052833s
2025-03-27T03:38:07.560643Z  INFO test_io_dummy_param::test: Total time: 101.796550458s
```