### PR TITLE
feat: update `GetPublicMatrixElement`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ default = ["test"]
 test = []
 parallel = ["rayon"]
 
+[dependencies]
 openfhe = { git = "https://github.com/MachinaIO/openfhe-rs.git", branch = "exp/trapdoor_gen" }
 digest = "0.10"
 num-bigint = { version = "0.4", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ test = []
 parallel = ["rayon"]
 
 [dependencies]
-openfhe = { git = "https://github.com/MachinaIO/openfhe-rs.git", branch = "feat/preimage_to_disk" }
+openfhe = { git = "https://github.com/MachinaIO/openfhe-rs.git", branch = "exp/trapdoor_gen" }
 digest = "0.10"
 num-bigint = { version = "0.4", default-features = false }
 num-traits = "0.2"

--- a/src/poly/dcrt/sampler/trapdoor.rs
+++ b/src/poly/dcrt/sampler/trapdoor.rs
@@ -165,6 +165,7 @@ impl PolyTrapdoorSampler for DCRTPolyTrapdoorSampler {
         params: &<<Self::M as PolyMatrix>::P as Poly>::Params,
         size: usize,
     ) -> (Self::Trapdoor, Self::M) {
+        log_mem("Before trap gen");
         let dcrt_trapdoor = DCRTTrapdoor::new(
             params.ring_dimension(),
             params.crt_depth(),
@@ -174,7 +175,9 @@ impl PolyTrapdoorSampler for DCRTPolyTrapdoorSampler {
             2_i64,
             false,
         );
+        log_mem("After trap gen");
         let rlwe_trapdoor = dcrt_trapdoor.get_trapdoor_pair();
+        log_mem("After get trapdoor pair");
         let nrow = size;
         let ncol = (&params.modulus_bits() + 2) * size;
         let public_matrix = DCRTPolyMatrix::from_poly_vec(
@@ -185,6 +188,7 @@ impl PolyTrapdoorSampler for DCRTPolyTrapdoorSampler {
                 })
                 .collect(),
         );
+        log_mem("After get public matrix");
         (rlwe_trapdoor, public_matrix)
     }
 


### PR DESCRIPTION
The original goal was to reduce the memory consumption on the trapdoor generation function. The experiment by logging directly from the C++ reveals that the big jump between `Before trapdoor gen` and `After trapdoor gen` is entirely due to the openfhe-development `TrapdoorGen` function so there's not much we can do there. 

Something else that I noticed is that in the current `main` there's a small memory increase when generating the public matrix (https://github.com/MachinaIO/diamond-io/blob/main/src/poly/dcrt/sampler/trapdoor.rs#L180-L187) due to duplication. 

This is fixed by an update on openfhe-rs -> https://github.com/MachinaIO/openfhe-rs/pull/5

You can see the benefits of this approach as there's no longer memory increase between `After trapdoor gen` and `After get_public_matrix`.

Next issues that I'm planning to tackle:

- [ ] apply the same technique to `GetMatrixElement`
- [ ] perform loops for `GetMatrixElement` and `SetMatrixElement in parallel

**Before**
```
Step Description                                                       Physical Memory Virtual Memory  Physical Change % Change   Virtual Change  % Change  
------------------------------------------------------------------------------------------------------------------------------------------------------
Sampled public data                                                    8.34 MB         391.33 GB       0.0 B           0.00%      0.0 B           0.00%
Sampled pub key init                                                   10.09 MB        391.47 GB       1.75 MB         20.97%      145.00 MB       0.04%
Sampled s_bars                                                         10.09 MB        391.47 GB       0.0 B           0.00%      0.0 B           0.00%
Sampled t_bar_matrix                                                   10.09 MB        391.47 GB       0.0 B           0.00%      0.0 B           0.00%
Sampled hardcoded_key_matrix                                           10.09 MB        391.47 GB       0.0 B           0.00%      0.0 B           0.00%
Sampled enc_hardcoded_key_polys                                        10.11 MB        391.48 GB       16.00 KB        0.15%      8.03 MB         0.00%
Sampled initial encodings                                              11.02 MB        391.48 GB       928.00 KB       8.96%      0.0 B           0.00%
Before trapdoor gen                                                    11.02 MB        391.48 GB       0.0 B           0.00%      0.0 B           0.00%
After trapdoor gen                                                     18.22 MB        391.52 GB       7.20 MB         65.39%      35.12 MB        0.01%
After get_trapdoor_pair                                                18.22 MB        391.52 GB       0.0 B           0.00%      0.0 B           0.00%
After get_public_matrix                                                18.38 MB        391.52 GB       160.00 KB       0.86%      0.0 B           0.00%
b star trapdoor init sampled                                           18.38 MB        391.52 GB       0.0 B           0.00%      0.0 B           0.00%
Computed p_init                                                        18.66 MB        391.52 GB       288.00 KB       1.53%      0.0 B           0.00%
Computed u_0, u_1, u_star                                              18.66 MB        391.52 GB       0.0 B           0.00%      0.0 B           0.00%
Before trapdoor gen                                                    18.66 MB        391.52 GB       0.0 B           0.00%      0.0 B           0.00%
After trapdoor gen                                                     23.53 MB        391.52 GB       4.88 MB         26.13%      2.00 MB         0.00%
After get_trapdoor_pair                                                23.53 MB        391.52 GB       0.0 B           0.00%      0.0 B           0.00%
After get_public_matrix                                                23.69 MB        391.52 GB       160.00 KB       0.66%      0.0 B           0.00%
Sampled b_star trapdoor for idx                                        23.69 MB        391.52 GB       0.0 B           0.00%      0.0 B           0.00%
Sampled pub key idx                                                    24.31 MB        391.52 GB       640.00 KB       2.64%      0.0 B           0.00%
Sampled b_star trapdoor for idx                                        24.31 MB        391.52 GB       0.0 B           0.00%      0.0 B           0.00%
Before trapdoor gen                                                    24.39 MB        391.52 GB       80.00 KB        0.32%      0.0 B           0.00%
After trapdoor gen                                                     29.73 MB        391.52 GB       5.34 MB         21.91%      3.00 MB         0.00%
After get_trapdoor_pair                                                29.73 MB        391.52 GB       0.0 B           0.00%      0.0 B           0.00%
After get_public_matrix                                                29.83 MB        391.52 GB       96.00 KB        0.32%      0.0 B           0.00%
Sampled b trapdoor for idx and bit                                     29.83 MB        391.52 GB       0.0 B           0.00%      0.0 B           0.00%
Collected preimages paths                                              81.58 MB        393.62 GB       51.75 MB        173.49%      2.10 GB         0.54%
Computed m_preimage_bit                                                81.58 MB        393.62 GB       0.0 B           0.00%      0.0 B           0.00%
Collected preimages paths                                              85.44 MB        393.62 GB       3.86 MB         4.73%      0.0 B           0.00%
Computed n_preimage_bit                                                85.44 MB        393.62 GB       0.0 B           0.00%      0.0 B           0.00%
Collected preimages paths                                              87.14 MB        393.62 GB       1.70 MB         1.99%      0.0 B           0.00%
Computed k_preimage_bit                                                87.14 MB        393.62 GB       0.0 B           0.00%      0.0 B           0.00%
Before trapdoor gen                                                    87.14 MB        393.62 GB       0.0 B           0.00%      0.0 B           0.00%
After trapdoor gen                                                     87.14 MB        393.62 GB       0.0 B           0.00%      0.0 B           0.00%
After get_trapdoor_pair                                                87.14 MB        393.62 GB       0.0 B           0.00%      0.0 B           0.00%
After get_public_matrix                                                87.14 MB        393.62 GB       0.0 B           0.00%      0.0 B           0.00%
Sampled b trapdoor for idx and bit                                     87.14 MB        393.62 GB       0.0 B           0.00%      0.0 B           0.00%
Collected preimages paths                                              90.64 MB        393.75 GB       3.50 MB         4.02%      131.00 MB       0.03%
Computed m_preimage_bit                                                90.64 MB        393.75 GB       0.0 B           0.00%      0.0 B           0.00%
Collected preimages paths                                              92.77 MB        393.75 GB       2.12 MB         2.34%      2.00 MB         0.00%
Computed n_preimage_bit                                                92.77 MB        393.75 GB       0.0 B           0.00%      0.0 B           0.00%
Collected preimages paths                                              94.98 MB        393.87 GB       2.22 MB         2.39%      129.00 MB       0.03%
Computed k_preimage_bit                                                94.98 MB        393.87 GB       0.0 B           0.00%      0.0 B           0.00%
Computed final_circuit                                                 94.98 MB        393.87 GB       0.0 B           0.00%      0.0 B           0.00%
Computed final_preimage_target                                         95.23 MB        393.87 GB       256.00 KB       0.26%      16.00 KB        0.00%
Collected preimages paths                                              95.23 MB        393.87 GB       0.0 B           0.00%      0.0 B           0.00%
Sampled final_preimage                                                 95.23 MB        393.87 GB       0.0 B           0.00%      0.0 B           0.00%
```

```
Time to obfuscate: 71.839009709s
```

**After**

```
Step Description                                                       Physical Memory Virtual Memory  Physical Change % Change   Virtual Change  % Change  
------------------------------------------------------------------------------------------------------------------------------------------------------
Sampled public data                                                    8.47 MB         391.34 GB       0.0 B           0.00%      0.0 B           0.00%
Sampled pub key init                                                   10.12 MB        391.47 GB       1.66 MB         19.56%      137.00 MB       0.03%
Sampled s_bars                                                         10.12 MB        391.47 GB       0.0 B           0.00%      0.0 B           0.00%
Sampled t_bar_matrix                                                   10.12 MB        391.47 GB       0.0 B           0.00%      0.0 B           0.00%
Sampled hardcoded_key_matrix                                           10.12 MB        391.47 GB       0.0 B           0.00%      0.0 B           0.00%
Sampled enc_hardcoded_key_polys                                        10.12 MB        391.47 GB       0.0 B           0.00%      0.0 B           0.00%
Sampled initial encodings                                              10.84 MB        391.47 GB       736.00 KB       7.10%      0.0 B           0.00%
Before trap gen                                                        10.84 MB        391.47 GB       0.0 B           0.00%      0.0 B           0.00%
After trap gen                                                         18.05 MB        391.51 GB       7.20 MB         66.43%      35.12 MB        0.01%
After get trapdoor pair                                                18.05 MB        391.51 GB       0.0 B           0.00%      0.0 B           0.00%
After get public matrix                                                18.05 MB        391.51 GB       0.0 B           0.00%      0.0 B           0.00%
b star trapdoor init sampled                                           18.05 MB        391.51 GB       0.0 B           0.00%      0.0 B           0.00%
Computed p_init                                                        18.05 MB        391.51 GB       0.0 B           0.00%      0.0 B           0.00%
Computed u_0, u_1, u_star                                              18.05 MB        391.51 GB       0.0 B           0.00%      0.0 B           0.00%
Before trap gen                                                        18.22 MB        391.51 GB       176.00 KB       0.95%      0.0 B           0.00%
After trap gen                                                         23.70 MB        391.51 GB       5.48 MB         30.10%      2.00 MB         0.00%
After get trapdoor pair                                                23.70 MB        391.51 GB       0.0 B           0.00%      0.0 B           0.00%
After get public matrix                                                23.70 MB        391.51 GB       0.0 B           0.00%      0.0 B           0.00%
Sampled b_star trapdoor for idx                                        23.70 MB        391.51 GB       0.0 B           0.00%      0.0 B           0.00%
Sampled pub key idx                                                    24.14 MB        391.52 GB       448.00 KB       1.85%      8.00 MB         0.00%
Sampled b_star trapdoor for idx                                        24.14 MB        391.52 GB       0.0 B           0.00%      0.0 B           0.00%
Before trap gen                                                        24.14 MB        391.52 GB       0.0 B           0.00%      0.0 B           0.00%
After trap gen                                                         27.98 MB        391.52 GB       3.84 MB         15.92%      3.00 MB         0.00%
After get trapdoor pair                                                28.83 MB        391.52 GB       864.00 KB       3.02%      0.0 B           0.00%
After get public matrix                                                28.86 MB        391.52 GB       32.00 KB        0.11%      0.0 B           0.00%
Sampled b trapdoor for idx and bit                                     28.86 MB        391.52 GB       0.0 B           0.00%      0.0 B           0.00%
Collected preimages paths                                              78.84 MB        393.62 GB       49.98 MB        173.20%      2.10 GB         0.54%
Computed m_preimage_bit                                                78.84 MB        393.62 GB       0.0 B           0.00%      0.0 B           0.00%
Collected preimages paths                                              82.28 MB        393.62 GB       3.44 MB         4.36%      1.00 MB         0.00%
Computed n_preimage_bit                                                82.28 MB        393.62 GB       0.0 B           0.00%      0.0 B           0.00%
Collected preimages paths                                              87.03 MB        393.62 GB       4.75 MB         5.77%      2.00 MB         0.00%
Computed k_preimage_bit                                                87.03 MB        393.62 GB       0.0 B           0.00%      0.0 B           0.00%
Before trap gen                                                        87.03 MB        393.62 GB       0.0 B           0.00%      0.0 B           0.00%
After trap gen                                                         87.05 MB        393.62 GB       16.00 KB        0.02%      0.0 B           0.00%
After get trapdoor pair                                                87.05 MB        393.62 GB       0.0 B           0.00%      0.0 B           0.00%
After get public matrix                                                87.05 MB        393.62 GB       0.0 B           0.00%      0.0 B           0.00%
Sampled b trapdoor for idx and bit                                     87.05 MB        393.62 GB       0.0 B           0.00%      0.0 B           0.00%
Collected preimages paths                                              89.03 MB        393.62 GB       1.98 MB         2.28%      1.00 MB         0.00%
Computed m_preimage_bit                                                89.03 MB        393.62 GB       0.0 B           0.00%      0.0 B           0.00%
Collected preimages paths                                              89.33 MB        393.87 GB       304.00 KB       0.33%      256.02 MB       0.06%
Computed n_preimage_bit                                                89.33 MB        393.87 GB       0.0 B           0.00%      0.0 B           0.00%
Collected preimages paths                                              90.53 MB        393.87 GB       1.20 MB         1.35%      1.00 MB         0.00%
Computed k_preimage_bit                                                90.53 MB        393.87 GB       0.0 B           0.00%      0.0 B           0.00%
Computed final_preimage_target                                         90.77 MB        393.87 GB       240.00 KB       0.26%      0.0 B           0.00%
Collected preimages paths                                              90.77 MB        393.87 GB       0.0 B           0.00%      0.0 B           0.00%
Sampled final_preimage                                                 90.77 MB        393.87 GB       0.0 B           0.00%      0.0 B           0.00%
```

```
Time to obfuscate: 74.560199375s
```