### PR TITLE
perf: circuit evaluation with dfs + chore: rm paralllel feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
           RUSTFLAGS: -A unused
 
       - name: Run test
-        run: cargo test --features="parallel"
+        run: cargo test
   
   ci-success:
     name: ci success

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,14 +8,13 @@ license = "MIT OR Apache-2.0"
 [features]
 default = ["test"]
 test = []
-parallel = ["rayon"]
 
 [dependencies]
 openfhe = { git = "https://github.com/MachinaIO/openfhe-rs.git" }
 digest = "0.10"
 num-bigint = { version = "0.4", default-features = false }
 num-traits = "0.2"
-rayon = { version = "1.5", optional = true }
+rayon = { version = "1.5" }
 rand = { version = "0.9.0", features = ["std_rng"] }
 itertools = "0.14.0"
 tracing = "0.1"
@@ -27,8 +26,9 @@ serde_json = "1.0"
 # mmap-storage = "0.10.0"
 memmap2 = "0.9.5"
 tempfile = "3.19.1"
-sysinfo = "0.33.1"
+sysinfo = "0.34.1"
 once_cell = "1.21.1"
+dashmap = "6.1.0"
 # for now we put in test
 
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Implementation of [Diamond iO](https://eprint.iacr.org/2025/236)
 #### Full Test (with test feature)
 
 ```
-cargo test -r  --features="parallel"
+cargo test -r
 ```
 
 #### Test iO (without test feature) 
@@ -15,15 +15,15 @@ this will remove helper logic + helper fields for test which is not require for 
 
 - dummy params
 ```
-cargo test -r --test test_io_dummy_param --no-default-features --features parallel -- --nocapture
+cargo test -r --test test_io_dummy_param --no-default-features -- --nocapture
 ```
 
 - real params (by default ignored)
 ```
-cargo test -r --test test_io_real_param --no-default-features --features parallel -- --ignored --nocapture
+cargo test -r --test test_io_real_param --no-default-features -- --ignored --nocapture
 ```
 
 - with memory profiler 
 ```
-uv run memory_profile.py cargo test -r --test test_io_dummy_param --no-default-features --features parallel
+uv run memory_profile.py cargo test -r --test test_io_dummy_param --no-default-features
 ```

--- a/justfile
+++ b/justfile
@@ -19,10 +19,10 @@ docs:
 
 # Execute all unit tests in the workspace
 test:
-   cargo test -r --features="parallel"
+   cargo test -r
 
 test-io:
-   cargo test -r --test test_io_dummy_param --no-default-features --features parallel
+   cargo test -r --test test_io_dummy_param --no-default-features
 
 # Run the entire CI pipeline including format, clippy, docs, and test checks
 ci: format clippy docs test test-io

--- a/src/bgg/circuit/eval.rs
+++ b/src/bgg/circuit/eval.rs
@@ -13,8 +13,10 @@ pub trait Evaluable:
     + for<'a> Add<&'a Self, Output = Self>
     + for<'a> Sub<&'a Self, Output = Self>
     + for<'a> Mul<&'a Self, Output = Self>
+    + Send
+    + Sync
 {
-    type Params: Debug + Clone;
+    type Params: Debug + Clone + Send + Sync;
     fn rotate(&self, params: &Self::Params, shift: usize) -> Self;
     fn from_bits(params: &Self::Params, one: &Self, bits: &[bool]) -> Self;
 }

--- a/src/bgg/circuit/eval.rs
+++ b/src/bgg/circuit/eval.rs
@@ -13,10 +13,8 @@ pub trait Evaluable:
     + for<'a> Add<&'a Self, Output = Self>
     + for<'a> Sub<&'a Self, Output = Self>
     + for<'a> Mul<&'a Self, Output = Self>
-    + Send
-    + Sync
 {
-    type Params: Debug + Clone + Send + Sync;
+    type Params: Debug + Clone;
     fn rotate(&self, params: &Self::Params, shift: usize) -> Self;
     fn from_bits(params: &Self::Params, one: &Self, bits: &[bool]) -> Self;
 }
@@ -34,7 +32,7 @@ impl<P: Poly> Evaluable for P {
         let poly = Self::const_zero(params);
         let mut coeffs = poly.coeffs();
         let one_elem = <P::Elem as PolyElem>::one(&params.modulus());
-        for (i, bit) in bits.iter().enumerate() {
+        for (i, bit) in bits.into_iter().enumerate() {
             if *bit {
                 coeffs[i] = one_elem.clone();
             }

--- a/src/bgg/circuit/eval.rs
+++ b/src/bgg/circuit/eval.rs
@@ -32,7 +32,7 @@ impl<P: Poly> Evaluable for P {
         let poly = Self::const_zero(params);
         let mut coeffs = poly.coeffs();
         let one_elem = <P::Elem as PolyElem>::one(&params.modulus());
-        for (i, bit) in bits.into_iter().enumerate() {
+        for (i, bit) in bits.iter().enumerate() {
             if *bit {
                 coeffs[i] = one_elem.clone();
             }

--- a/src/bgg/circuit/mod.rs
+++ b/src/bgg/circuit/mod.rs
@@ -202,26 +202,27 @@ impl PolyCircuit {
     fn topological_order(&self) -> Vec<usize> {
         let mut visited = HashSet::new();
         let mut order = Vec::new();
-
-        fn dfs(
-            circuit: &PolyCircuit,
-            gate_id: usize,
-            visited: &mut HashSet<usize>,
-            order: &mut Vec<usize>,
-        ) {
-            if !visited.insert(gate_id) {
-                return;
-            }
-            let gate = circuit.gates.get(&gate_id).expect("gate not found");
-            for &input_id in &gate.input_gates {
-                dfs(circuit, input_id, visited, order);
-            }
-            order.push(gate_id);
-        }
-
+        let mut stack = Vec::new();
         for &output_gate in &self.output_ids {
-            dfs(self, output_gate, &mut visited, &mut order);
+            if visited.insert(output_gate) {
+                stack.push((output_gate, 0));
+            }
         }
+
+        while let Some((node, child_idx)) = stack.pop() {
+            let gate = self.gates.get(&node).expect("gate not found");
+
+            if child_idx < gate.input_gates.len() {
+                stack.push((node, child_idx + 1));
+                let child = gate.input_gates[child_idx];
+                if visited.insert(child) {
+                    stack.push((child, 0));
+                }
+            } else {
+                order.push(node);
+            }
+        }
+
         order
     }
 

--- a/src/bgg/circuit/mod.rs
+++ b/src/bgg/circuit/mod.rs
@@ -147,6 +147,7 @@ impl PolyCircuit {
         let mut outputs = Vec::with_capacity(sub_circuit.num_output());
         let base_gate_id = self.gates.len();
         for idx in 0..sub_circuit.num_output() {
+            println!("output_id: {}", base_gate_id + idx);
             let gate_id = self.new_gate_generic(
                 inputs.to_vec(),
                 PolyGateType::Call {
@@ -285,6 +286,7 @@ impl PolyCircuit {
                     .collect();
                 let outputs = sub_circuit.eval(params, one, &sub_inputs);
                 for (idx, output_wire) in outputs.into_iter().enumerate() {
+                    println!("call polygate :{}", output_id + idx);
                     wires.insert(output_id + idx, output_wire);
                 }
                 wires.get(output_id).expect("sub-circuit output missing").clone()
@@ -313,8 +315,8 @@ impl PolyCircuit {
                 let gate = self.gates.get(&gate_id).expect("gate not found").clone();
                 let res = self.eval_gate(params, one, &wires, &gate);
                 wires.insert(gate.gate_id, res);
-                debug_mem("Evaluated gate in parallel");
             });
+            debug_mem("Evaluated gate in parallel");
         }
 
         self.output_ids

--- a/src/bgg/sampler.rs
+++ b/src/bgg/sampler.rs
@@ -9,7 +9,6 @@ use crate::{
     },
 };
 use itertools::Itertools;
-#[cfg(feature = "parallel")]
 use rayon::prelude::*;
 use std::{marker::PhantomData, sync::Arc};
 

--- a/src/poly/dcrt/matrix.rs
+++ b/src/poly/dcrt/matrix.rs
@@ -68,8 +68,8 @@ impl PolyMatrix for DCRTPolyMatrix {
         let f = |row_offsets: Range<usize>, col_offsets: Range<usize>| -> Vec<Vec<Self::P>> {
             let row_offsets = row_start + row_offsets.start..row_start + row_offsets.end;
             let col_offsets = col_start + col_offsets.start..col_start + col_offsets.end;
-            let new_entries = self.block_entries(row_offsets, col_offsets);
-            new_entries
+
+            self.block_entries(row_offsets, col_offsets)
         };
         new_matrix.replace_entries(0..nrow, 0..ncol, f);
         new_matrix
@@ -465,8 +465,8 @@ impl Add<&DCRTPolyMatrix> for DCRTPolyMatrix {
          -> Vec<Vec<<Self as PolyMatrix>::P>> {
             let self_block_polys = self.block_entries(row_offsets.clone(), col_offsets.clone());
             let rhs_block_polys = rhs.block_entries(row_offsets, col_offsets);
-            let new_block_polys = add_block_matrices(self_block_polys, &rhs_block_polys);
-            new_block_polys
+
+            add_block_matrices(self_block_polys, &rhs_block_polys)
         };
         new_matrix.replace_entries(0..self.nrow, 0..self.ncol, f);
         new_matrix
@@ -499,8 +499,8 @@ impl Sub<&DCRTPolyMatrix> for DCRTPolyMatrix {
          -> Vec<Vec<<Self as PolyMatrix>::P>> {
             let self_block_polys = self.block_entries(row_offsets.clone(), col_offsets.clone());
             let rhs_block_polys = rhs.block_entries(row_offsets, col_offsets);
-            let new_block_polys = sub_block_matrices(self_block_polys, &rhs_block_polys);
-            new_block_polys
+
+            sub_block_matrices(self_block_polys, &rhs_block_polys)
         };
         new_matrix.replace_entries(0..self.nrow, 0..self.ncol, f);
         new_matrix
@@ -761,7 +761,7 @@ unsafe fn map_file_mut(file: &File, offset: usize, len: usize) -> MmapMut {
 
 fn block_offsets(rows: Range<usize>, cols: Range<usize>) -> (Vec<usize>, Vec<usize>) {
     let block_size =
-        env::var("BLOCK_SIZE").map(|str| usize::from_str_radix(&str, 10).unwrap()).unwrap_or(1000);
+        env::var("BLOCK_SIZE").map(|str| str.parse::<usize>().unwrap()).unwrap_or(1000);
     // *BLOCK_SIZE.get().unwrap();
     let nrow = rows.end - rows.start;
     let ncol = cols.end - cols.start;

--- a/src/poly/dcrt/matrix.rs
+++ b/src/poly/dcrt/matrix.rs
@@ -6,7 +6,6 @@ use crate::{
 use itertools::Itertools;
 use memmap2::{Mmap, MmapMut, MmapOptions};
 use num_bigint::BigInt;
-#[cfg(feature = "parallel")]
 use rayon::prelude::*;
 use std::{
     env,

--- a/src/poly/dcrt/poly.rs
+++ b/src/poly/dcrt/poly.rs
@@ -1,5 +1,4 @@
 use itertools::Itertools;
-#[cfg(feature = "parallel")]
 use rayon::prelude::*;
 
 use super::{element::FinRingElem, params::DCRTPolyParams};

--- a/src/poly/dcrt/sampler/hash.rs
+++ b/src/poly/dcrt/sampler/hash.rs
@@ -10,7 +10,6 @@ use bitvec::prelude::*;
 use digest::OutputSizeUser;
 use num_bigint::BigUint;
 use num_traits::Zero;
-#[cfg(feature = "parallel")]
 use rayon::prelude::*;
 use std::{marker::PhantomData, ops::Range};
 
@@ -146,13 +145,8 @@ where
 mod tests {
     use super::*;
     use crate::poly::dcrt::DCRTPolyParams;
-    #[cfg(not(feature = "parallel"))]
-    use itertools::Itertools;
+
     use keccak_asm::Keccak256;
-    #[cfg(not(feature = "parallel"))]
-    use proptest::prelude::*;
-    #[cfg(not(feature = "parallel"))]
-    use std::sync::Arc;
 
     #[test]
     fn test_poly_hash_sampler() {
@@ -191,7 +185,7 @@ mod tests {
         assert_eq!(matrix.col_size(), ncol, "Matrix column count mismatch");
     }
 
-    #[cfg(not(feature = "parallel"))]
+    #[cfg(not(feature = "test"))]
     proptest! {
         #![proptest_config(ProptestConfig::with_cases(10))]
 

--- a/src/poly/dcrt/sampler/trapdoor.rs
+++ b/src/poly/dcrt/sampler/trapdoor.rs
@@ -7,7 +7,6 @@ use crate::{
     },
     utils::{debug_mem, log_mem},
 };
-#[cfg(feature = "parallel")]
 use rayon::prelude::*;
 use std::{path::PathBuf, sync::Arc};
 

--- a/src/poly/dcrt/sampler/uniform.rs
+++ b/src/poly/dcrt/sampler/uniform.rs
@@ -1,7 +1,5 @@
-use std::ops::Range;
-
-#[cfg(feature = "parallel")]
 use rayon::prelude::*;
+use std::ops::Range;
 
 use crate::{
     parallel_iter,
@@ -81,14 +79,6 @@ impl PolyUniformSampler for DCRTPolyUniformSampler {
 #[cfg(feature = "test")]
 mod tests {
     use super::*;
-    #[cfg(not(feature = "parallel"))]
-    use itertools::Itertools;
-    #[cfg(not(feature = "parallel"))]
-    use num_bigint::BigUint;
-    #[cfg(not(feature = "parallel"))]
-    use proptest::prelude::*;
-    #[cfg(not(feature = "parallel"))]
-    use std::sync::Arc;
 
     #[test]
     fn test_ring_dist() {
@@ -171,7 +161,7 @@ mod tests {
         assert_eq!(mult_matrix.col_size(), 12);
     }
 
-    #[cfg(not(feature = "parallel"))]
+    #[cfg(not(feature = "test"))]
     proptest::proptest! {
         #![proptest_config(ProptestConfig::with_cases(10))]
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -105,28 +105,7 @@ pub fn init_tracing() {
 #[macro_export]
 macro_rules! parallel_iter {
     ($i: expr) => {{
-        #[cfg(not(feature = "parallel"))]
-        {
-            IntoIterator::into_iter($i)
-        }
-        #[cfg(feature = "parallel")]
-        {
-            rayon::iter::IntoParallelIterator::into_par_iter($i)
-        }
-    }};
-}
-
-#[macro_export]
-macro_rules! join {
-    ($a:expr, $b:expr $(,)?) => {{
-        #[cfg(not(feature = "parallel"))]
-        {
-            ($a(), $b())
-        }
-        #[cfg(feature = "parallel")]
-        {
-            rayon::join($a, $b)
-        }
+        rayon::iter::IntoParallelIterator::into_par_iter($i)
     }};
 }
 


### PR DESCRIPTION
- Topologically Sort and Iterate: basically return dependency order that ensures for any gate, all its dependencies (input gates) are processed before the gate itself
- with given dependency order, we no need perform recursive evaluation for prior gate like this (https://github.com/MachinaIO/diamond-io/blob/main/src/bgg/circuit/mod.rs#L228-L234) , so to reduce non necessary function call
- also removed `paralllel` feature as we not needed 

## time  - dummy param - mac m2

before
```
Time to obfuscate: 297.504950042s
Time for evaluation: 402.378013875s
Total time: 699.882963917s
```

after
```
Time to obfuscate: 285.641014709s
Time for evaluation: 385.333062416s
Total time: 670.974077125s
```
