### PR TITLE
Fix : rlwe encryption

### DIFF
--- a/src/io/eval.rs
+++ b/src/io/eval.rs
@@ -227,6 +227,6 @@ where
             debug_assert_eq!(z.size(), (1, packed_output_size));
             debug_assert_eq!(z.entry(0, 0), output_encoding_ints[0].plaintext.clone().unwrap());
         }
-        z.get_row(0).into_iter().flat_map(|p| p.extract_highest_bits()).collect_vec()
+        z.get_row(0).into_iter().flat_map(|p| p.extract_bits_with_threshold(&params)).collect_vec()
     }
 }

--- a/src/io/obf.rs
+++ b/src/io/obf.rs
@@ -20,6 +20,7 @@ pub fn obfuscate<M, SU, SH, ST, R>(
     sampler_uniform: SU,
     mut sampler_hash: SH,
     sampler_trapdoor: ST,
+    hardcoded_key: M::P,
     rng: &mut R,
 ) -> Obfuscation<M>
 where
@@ -67,7 +68,7 @@ where
     let t_bar_matrix = sampler_uniform.sample_uniform(&params, 1, 1, DistType::FinRingDist);
     log_mem("Sampled t_bar_matrix");
 
-    let hardcoded_key_matrix = sampler_uniform.sample_uniform(&params, 1, 1, DistType::BitDist);
+    let hardcoded_key_matrix = M::from_poly_vec_row(&params, vec![hardcoded_key]);
     log_mem("Sampled hardcoded_key_matrix");
 
     let enc_hardcoded_key = {

--- a/src/poly/dcrt/poly.rs
+++ b/src/poly/dcrt/poly.rs
@@ -274,6 +274,22 @@ impl Poly for DCRTPoly {
             .map(|coeff| coeff >= &quarter_q && coeff < &three_quarter_q)
             .collect()
     }
+
+    fn to_bool_vec(&self) -> Vec<bool> {
+        self.coeffs()
+            .into_iter()
+            .map(|c| {
+                let v = c.value();
+                if v == &BigUint::from(0u32) {
+                    false
+                } else if v == &BigUint::from(1u32) {
+                    true
+                } else {
+                    panic!("Coefficient is not 0 or 1: {}", v);
+                }
+            })
+            .collect()
+    }
 }
 
 impl PartialEq for DCRTPoly {

--- a/src/poly/dcrt/poly.rs
+++ b/src/poly/dcrt/poly.rs
@@ -261,6 +261,19 @@ impl Poly for DCRTPoly {
 
         result
     }
+
+    /// Recover bits from a polynomial using decision thresholds q/4 and 3q/4
+    fn extract_bits_with_threshold(&self, params: &Self::Params) -> Vec<bool> {
+        let modulus = params.modulus();
+        let quarter_q = modulus.as_ref() >> 2; // q/4
+        let three_quarter_q = &quarter_q * 3u32; // 3q/4
+
+        self.coeffs()
+            .iter()
+            .map(|coeff| coeff.value())
+            .map(|coeff| coeff >= &quarter_q && coeff < &three_quarter_q)
+            .collect()
+    }
 }
 
 impl PartialEq for DCRTPoly {

--- a/src/poly/mod.rs
+++ b/src/poly/mod.rs
@@ -12,3 +12,35 @@ pub use element::PolyElem;
 pub use matrix::PolyMatrix;
 pub use params::PolyParams;
 pub use polynomial::Poly;
+
+use sampler::{DistType, PolyUniformSampler};
+use std::sync::Arc;
+
+pub fn rlwe_encrypt<M, SU>(
+    params: &Arc<<<M as PolyMatrix>::P as Poly>::Params>,
+    sampler_uniform: &Arc<SU>,
+    t: &M,
+    a: &M,
+    m: &M,
+    sigma: f64,
+) -> M
+where
+    M: PolyMatrix,
+    SU: PolyUniformSampler<M = M>,
+{
+    assert!(m.row_size() == 1);
+    assert!(m.col_size() == 1);
+    assert!(t.row_size() == 1);
+    assert!(t.col_size() == 1);
+    assert!(a.row_size() == 1);
+    assert!(a.col_size() == 1);
+
+    // Sample error from Gaussian distribution
+    let e = sampler_uniform.sample_uniform(params.as_ref(), 1, 1, DistType::GaussDist { sigma });
+
+    // Use provided scale or calculate half of q
+    let scale = M::P::from_const(params, &<M::P as Poly>::Elem::half_q(&params.modulus()));
+
+    // Compute RLWE encryption: t * a + e - (m * scale)
+    t.clone() * a + &e - &(m.clone() * &scale)
+}

--- a/src/poly/polynomial.rs
+++ b/src/poly/polynomial.rs
@@ -69,5 +69,6 @@ pub trait Poly:
         }
         bytes
     }
+    fn to_bool_vec(&self) -> Vec<bool>;
     fn to_compact_bytes(&self) -> Vec<u8>;
 }

--- a/src/poly/polynomial.rs
+++ b/src/poly/polynomial.rs
@@ -60,6 +60,7 @@ pub trait Poly:
         }
         bits
     }
+    fn extract_bits_with_threshold(&self, params: &Self::Params) -> Vec<bool>;
     fn decompose_bits(&self, params: &Self::Params) -> Vec<Self>;
     fn to_bytes(&self) -> Vec<u8> {
         let mut bytes = Vec::new();

--- a/tests/test_io_dummy_param.rs
+++ b/tests/test_io_dummy_param.rs
@@ -8,6 +8,7 @@ mod test {
                 DCRTPolyHashSampler, DCRTPolyMatrix, DCRTPolyParams, DCRTPolyTrapdoorSampler,
                 DCRTPolyUniformSampler,
             },
+            sampler::DistType,
             Poly, PolyParams,
         },
         utils::init_tracing,
@@ -45,7 +46,7 @@ mod test {
             public_circuit: public_circuit.clone(),
             d: 3,
             encoding_sigma: 0.0,
-            hardcoded_key_sigma: 0.0,
+            hardcoded_key_sigma: 3.0,
             p_sigma: 0.0,
         };
 
@@ -53,11 +54,13 @@ mod test {
         let sampler_hash = DCRTPolyHashSampler::<Keccak256>::new([0; 32]);
         let sampler_trapdoor = DCRTPolyTrapdoorSampler::new(&params, SIGMA);
         let mut rng = rand::rng();
+        let hardcoded_key = sampler_uniform.sample_poly(&params, &DistType::BitDist);
         let obfuscation = obfuscate::<DCRTPolyMatrix, _, _, _, _>(
             obf_params.clone(),
             sampler_uniform,
             sampler_hash,
             sampler_trapdoor,
+            hardcoded_key,
             &mut rng,
         );
         let obfuscation_time = start_time.elapsed();

--- a/tests/test_io_middle_param.rs
+++ b/tests/test_io_middle_param.rs
@@ -8,6 +8,7 @@ mod test {
                 DCRTPolyHashSampler, DCRTPolyMatrix, DCRTPolyParams, DCRTPolyTrapdoorSampler,
                 DCRTPolyUniformSampler,
             },
+            sampler::DistType,
             Poly, PolyParams,
         },
         utils::init_tracing,
@@ -55,11 +56,13 @@ mod test {
         let sampler_hash = DCRTPolyHashSampler::<Keccak256>::new([0; 32]);
         let sampler_trapdoor = DCRTPolyTrapdoorSampler::new(&params, SIGMA);
         let mut rng = rand::rng();
+        let hardcoded_key = sampler_uniform.sample_poly(&params, &DistType::BitDist);
         let obfuscation = obfuscate::<DCRTPolyMatrix, _, _, _, _>(
             obf_params.clone(),
             sampler_uniform,
             sampler_hash,
             sampler_trapdoor,
+            hardcoded_key,
             &mut rng,
         );
         let obfuscation_time = start_time.elapsed();

--- a/tests/test_io_real_param.rs
+++ b/tests/test_io_real_param.rs
@@ -8,6 +8,7 @@ mod test {
                 DCRTPolyHashSampler, DCRTPolyMatrix, DCRTPolyParams, DCRTPolyTrapdoorSampler,
                 DCRTPolyUniformSampler,
             },
+            sampler::DistType,
             Poly, PolyParams,
         },
         utils::init_tracing,
@@ -55,11 +56,13 @@ mod test {
         let sampler_hash = DCRTPolyHashSampler::<Keccak256>::new([0; 32]);
         let sampler_trapdoor = DCRTPolyTrapdoorSampler::new(&params, SIGMA);
         let mut rng = rand::rng();
+        let hardcoded_key = sampler_uniform.sample_poly(&params, &DistType::BitDist);
         let obfuscation = obfuscate::<DCRTPolyMatrix, _, _, _, _>(
             obf_params.clone(),
             sampler_uniform,
             sampler_hash,
             sampler_trapdoor,
+            hardcoded_key,
             &mut rng,
         );
         let obfuscation_time = start_time.elapsed();


### PR DESCRIPTION
Issue originally discussed in #74 as part of a larger PR.

The io test fails when setting `hardcoded_key_sigma` to any value different than 0. That's because the bits from the noisy plaintext are recovered using `extract_highest_bits()`. As an example, if message bit is 0 and error is negative, the resulting recovered highest bit will be 1 which is not correct

The new logic to recover the message bits implemented in this PR is based on [hackmd](https://hackmd.io/TqUeL_F8QMCdAq3dxMbhkg#RLWE-secret-key-encryption)