### PR TITLE
Feat: optimize ip circuit

### DIFF
--- a/memory_profile.py
+++ b/memory_profile.py
@@ -66,7 +66,7 @@ def analyze_memory_usage_from_string(log_output):
     
     # Pattern for lines with message
     pattern_with_message = re.compile(
-        r".*?diamond_io::utils\s*:\s*(.*?)\s*\|\|\s*Current physical/virtural memory usage:\s*(\d+)\s*\|\s*(\d+)"
+        r".*?diamond_io::utils\s*:\s*(.*?)\s*\|\|\s*Current physical/virtual memory usage:\s*(\d+)\s*\|\s*(\d+)"
     )
     
     # Pattern for lines with just numbers

--- a/src/bgg/circuit/mod.rs
+++ b/src/bgg/circuit/mod.rs
@@ -778,7 +778,7 @@ mod tests {
         assert_eq!(b_eval, &b * &x);
 
         // decrypt the result
-        let plaintext = a_eval * t - b_eval;
+        let plaintext = b_eval - (a_eval * t);
         // recover the message bits
         let plaintext_bits = plaintext.extract_bits_with_threshold(&params);
         assert_eq!(plaintext_bits, (m * x).to_bool_vec());

--- a/src/io/eval.rs
+++ b/src/io/eval.rs
@@ -69,7 +69,7 @@ where
                 for _ in 0..(obf_params.input_size.div_ceil(params.ring_dimension() as usize)) {
                     polys.push(zero.clone());
                 }
-                polys.push(self.t_bar.clone());
+                polys.push(self.minus_t_bar.clone());
                 let gadget_d1 = M::gadget_matrix(&params, d1);
                 M::from_poly_vec_row(params.as_ref(), polys).tensor(&gadget_d1)
             };
@@ -160,7 +160,7 @@ where
                             .map(|coeffs| M::P::from_coeffs(&params, coeffs))
                             .collect_vec();
                         polys.extend(input_polys);
-                        polys.push(self.t_bar.clone());
+                        polys.push(self.minus_t_bar.clone());
                         M::from_poly_vec_row(params.as_ref(), polys).tensor(&gadget_d1)
                     };
                     let pubkey = pubkeys[idx + 1][0].concat_matrix(&pubkeys[idx + 1][1..]);

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -1,28 +1,28 @@
-// use crate::{bgg::BggEncoding, poly::PolyMatrix};
+use crate::{bgg::BggEncoding, poly::PolyMatrix};
 
-// pub mod eval;
-// pub mod obf;
-// pub mod params;
-// pub mod utils;
+pub mod eval;
+pub mod obf;
+pub mod params;
+pub mod utils;
 
-// #[derive(Debug, Clone)]
-// pub struct Obfuscation<M: PolyMatrix> {
-//     pub hash_key: [u8; 32],
-//     pub ct_b: M,
-//     pub encodings_init: Vec<BggEncoding<M>>,
-//     pub p_init: M,
-//     pub m_preimages: Vec<Vec<M>>,
-//     pub n_preimages: Vec<Vec<M>>,
-//     pub k_preimages: Vec<Vec<M>>,
-//     pub final_preimage: M,
-//     #[cfg(feature = "test")]
-//     pub s_init: M,
-//     #[cfg(feature = "test")]
-//     pub t_bar: <M as PolyMatrix>::P,
-//     #[cfg(feature = "test")]
-//     pub bs: Vec<Vec<M>>,
-//     #[cfg(feature = "test")]
-//     pub hardcoded_key: <M as PolyMatrix>::P,
-//     #[cfg(feature = "test")]
-//     pub final_preimage_target: M,
-// }
+#[derive(Debug, Clone)]
+pub struct Obfuscation<M: PolyMatrix> {
+    pub hash_key: [u8; 32],
+    pub ct_b: M,
+    pub encodings_init: Vec<BggEncoding<M>>,
+    pub p_init: M,
+    pub m_preimages: Vec<Vec<M>>,
+    pub n_preimages: Vec<Vec<M>>,
+    pub k_preimages: Vec<Vec<M>>,
+    pub final_preimage: M,
+    #[cfg(feature = "test")]
+    pub s_init: M,
+    #[cfg(feature = "test")]
+    pub minus_t_bar: <M as PolyMatrix>::P,
+    #[cfg(feature = "test")]
+    pub bs: Vec<Vec<M>>,
+    #[cfg(feature = "test")]
+    pub hardcoded_key: <M as PolyMatrix>::P,
+    #[cfg(feature = "test")]
+    pub final_preimage_target: M,
+}

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -1,28 +1,28 @@
-use crate::{bgg::BggEncoding, poly::PolyMatrix};
+// use crate::{bgg::BggEncoding, poly::PolyMatrix};
 
-pub mod eval;
-pub mod obf;
-pub mod params;
-pub mod utils;
+// pub mod eval;
+// pub mod obf;
+// pub mod params;
+// pub mod utils;
 
-#[derive(Debug, Clone)]
-pub struct Obfuscation<M: PolyMatrix> {
-    pub hash_key: [u8; 32],
-    pub ct_b: M,
-    pub encodings_init: Vec<BggEncoding<M>>,
-    pub p_init: M,
-    pub m_preimages: Vec<Vec<M>>,
-    pub n_preimages: Vec<Vec<M>>,
-    pub k_preimages: Vec<Vec<M>>,
-    pub final_preimage: M,
-    #[cfg(feature = "test")]
-    pub s_init: M,
-    #[cfg(feature = "test")]
-    pub t_bar: <M as PolyMatrix>::P,
-    #[cfg(feature = "test")]
-    pub bs: Vec<Vec<M>>,
-    #[cfg(feature = "test")]
-    pub hardcoded_key: <M as PolyMatrix>::P,
-    #[cfg(feature = "test")]
-    pub final_preimage_target: M,
-}
+// #[derive(Debug, Clone)]
+// pub struct Obfuscation<M: PolyMatrix> {
+//     pub hash_key: [u8; 32],
+//     pub ct_b: M,
+//     pub encodings_init: Vec<BggEncoding<M>>,
+//     pub p_init: M,
+//     pub m_preimages: Vec<Vec<M>>,
+//     pub n_preimages: Vec<Vec<M>>,
+//     pub k_preimages: Vec<Vec<M>>,
+//     pub final_preimage: M,
+//     #[cfg(feature = "test")]
+//     pub s_init: M,
+//     #[cfg(feature = "test")]
+//     pub t_bar: <M as PolyMatrix>::P,
+//     #[cfg(feature = "test")]
+//     pub bs: Vec<Vec<M>>,
+//     #[cfg(feature = "test")]
+//     pub hardcoded_key: <M as PolyMatrix>::P,
+//     #[cfg(feature = "test")]
+//     pub final_preimage_target: M,
+// }

--- a/src/io/obf.rs
+++ b/src/io/obf.rs
@@ -91,12 +91,12 @@ where
 
     log_mem("Decomposed RLWE ciphertext into {bits(a), bits(b)}");
 
-    let t_bar = t_bar_matrix.entry(0, 0);
+    let minus_t_bar = -t_bar_matrix.entry(0, 0);
 
     let mut plaintexts = (0..obf_params.input_size.div_ceil(dim))
         .map(|_| M::P::const_zero(params.as_ref()))
         .collect_vec();
-    plaintexts.push(t_bar.clone());
+    plaintexts.push(minus_t_bar.clone());
 
     let encodings_init = bgg_encode_sampler.sample(&params, &pub_key_init, &plaintexts);
     log_mem("Sampled initial encodings");
@@ -273,7 +273,7 @@ where
         #[cfg(feature = "test")]
         s_init: s_init.clone(),
         #[cfg(feature = "test")]
-        t_bar,
+        minus_t_bar,
         #[cfg(feature = "test")]
         bs,
         #[cfg(feature = "test")]

--- a/src/poly/enc.rs
+++ b/src/poly/enc.rs
@@ -26,8 +26,8 @@ where
     // Use provided scale or calculate half of q
     let scale = M::P::from_const(params, &<M::P as Poly>::Elem::half_q(&params.modulus()));
 
-    // Compute RLWE encryption: t * a + (e - (m * scale))
-    t.clone() * a + e - &(m.clone() * &scale)
+    // Compute RLWE encryption: t * a + e + m * scale)
+    t.clone() * a + e + &(m.clone() * &scale)
 }
 
 #[cfg(test)]
@@ -59,7 +59,7 @@ mod tests {
         let b = rlwe_encrypt(&params, &sampler, &t_mat, &a_mat, &m_mat, sigma);
 
         // Decrypt the ciphertext and recover the message bits
-        let recovered = ((a_mat * t_mat) - b).entry(0, 0);
+        let recovered = (b - (a_mat * t_mat)).entry(0, 0);
         let recovered_bits = recovered.extract_bits_with_threshold(&params);
 
         // Verify correctness

--- a/src/poly/enc.rs
+++ b/src/poly/enc.rs
@@ -26,7 +26,7 @@ where
     // Use provided scale or calculate half of q
     let scale = M::P::from_const(params, &<M::P as Poly>::Elem::half_q(&params.modulus()));
 
-    // Compute RLWE encryption: t * a + e + m * scale)
+    // Compute RLWE encryption: t * a + e + m * scale
     t.clone() * a + e + &(m.clone() * &scale)
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -106,7 +106,7 @@ pub fn log_mem<T: Into<String>>(tag: T) {
 pub fn debug_mem<T: Into<String>>(tag: T) {
     if let Some(usage) = memory_stats() {
         debug!(
-            "{} || Current physical/virtural memory usage: {} | {}",
+            "{} || Current physical/virtual memory usage: {} | {}",
             tag.into(),
             usage.physical_mem,
             usage.virtual_mem

--- a/tests/test_io_dummy_param.rs
+++ b/tests/test_io_dummy_param.rs
@@ -1,98 +1,98 @@
-// #[cfg(test)]
-// mod test {
-//     use diamond_io::{
-//         bgg::circuit::PolyCircuit,
-//         io::{obf::obfuscate, params::ObfuscationParams},
-//         poly::{
-//             dcrt::{
-//                 DCRTPoly, DCRTPolyHashSampler, DCRTPolyMatrix, DCRTPolyParams,
-//                 DCRTPolyTrapdoorSampler, DCRTPolyUniformSampler, FinRingElem,
-//             },
-//             sampler::DistType,
-//             Poly, PolyElem, PolyParams,
-//         },
-//         utils::init_tracing,
-//     };
-//     use keccak_asm::Keccak256;
-//     use num_bigint::BigUint;
-//     use rand::Rng;
-//     use std::sync::Arc;
-//     use tracing::info;
+#[cfg(test)]
+mod test {
+    use diamond_io::{
+        bgg::circuit::PolyCircuit,
+        io::{obf::obfuscate, params::ObfuscationParams},
+        poly::{
+            dcrt::{
+                DCRTPoly, DCRTPolyHashSampler, DCRTPolyMatrix, DCRTPolyParams,
+                DCRTPolyTrapdoorSampler, DCRTPolyUniformSampler, FinRingElem,
+            },
+            sampler::DistType,
+            Poly, PolyElem, PolyParams,
+        },
+        utils::init_tracing,
+    };
+    use keccak_asm::Keccak256;
+    use num_bigint::BigUint;
+    use rand::Rng;
+    use std::sync::Arc;
+    use tracing::info;
 
-//     const SIGMA: f64 = 4.578;
+    const SIGMA: f64 = 4.578;
 
-//     #[test]
-//     fn test_io_just_mul_enc_and_and_bit() {
-//         init_tracing();
-//         let start_time = std::time::Instant::now();
-//         let params = DCRTPolyParams::new(4, 2, 17, 10);
-//         let log_q = params.modulus_bits();
-//         let switched_modulus = Arc::new(BigUint::from(1u32));
-//         let mut public_circuit = PolyCircuit::new();
+    #[test]
+    fn test_io_just_mul_enc_and_and_bit() {
+        init_tracing();
+        let start_time = std::time::Instant::now();
+        let params = DCRTPolyParams::new(4, 2, 17, 10);
+        let log_q = params.modulus_bits();
+        let switched_modulus = Arc::new(BigUint::from(1u32));
+        let mut public_circuit = PolyCircuit::new();
 
-//         // inputs: BITS(ct), eval_input
-//         // outputs: BITS(ct) AND eval_input, BITS(ct) AND eval_input
-//         {
-//             let inputs = public_circuit.input((2 * log_q) + 1);
-//             let mut outputs = vec![];
-//             let eval_input = inputs[2 * log_q];
-//             for ct_input in inputs[0..2 * log_q].iter() {
-//                 let muled = public_circuit.and_gate(*ct_input, eval_input);
-//                 outputs.push(muled);
-//             }
-//             for ct_input in inputs[0..2 * log_q].iter() {
-//                 let muled = public_circuit.and_gate(*ct_input, eval_input);
-//                 outputs.push(muled);
-//             }
-//             public_circuit.output(outputs);
-//         }
+        // inputs: BITS(ct), eval_input
+        // outputs: BITS(ct) AND eval_input, BITS(ct) AND eval_input
+        {
+            let inputs = public_circuit.input((2 * log_q) + 1);
+            let mut outputs = vec![];
+            let eval_input = inputs[2 * log_q];
+            for ct_input in inputs[0..2 * log_q].iter() {
+                let muled = public_circuit.and_gate(*ct_input, eval_input);
+                outputs.push(muled);
+            }
+            for ct_input in inputs[0..2 * log_q].iter() {
+                let muled = public_circuit.and_gate(*ct_input, eval_input);
+                outputs.push(muled);
+            }
+            public_circuit.output(outputs);
+        }
 
-//         let obf_params = ObfuscationParams {
-//             params: params.clone(),
-//             switched_modulus,
-//             input_size: 1,
-//             public_circuit: public_circuit.clone(),
-//             d: 3,
-//             encoding_sigma: 0.0,
-//             hardcoded_key_sigma: 0.0,
-//             p_sigma: 0.0,
-//         };
+        let obf_params = ObfuscationParams {
+            params: params.clone(),
+            switched_modulus,
+            input_size: 1,
+            public_circuit: public_circuit.clone(),
+            d: 3,
+            encoding_sigma: 0.0,
+            hardcoded_key_sigma: 0.0,
+            p_sigma: 0.0,
+        };
 
-//         let sampler_uniform = DCRTPolyUniformSampler::new();
-//         let sampler_hash = DCRTPolyHashSampler::<Keccak256>::new([0; 32]);
-//         let sampler_trapdoor = DCRTPolyTrapdoorSampler::new(&params, SIGMA);
-//         let mut rng = rand::rng();
-//         let hardcoded_key = sampler_uniform.sample_poly(&params, &DistType::BitDist);
-//         let obfuscation = obfuscate::<DCRTPolyMatrix, _, _, _, _>(
-//             obf_params.clone(),
-//             sampler_uniform,
-//             sampler_hash,
-//             sampler_trapdoor,
-//             hardcoded_key.clone(),
-//             &mut rng,
-//         );
-//         let obfuscation_time = start_time.elapsed();
-//         info!("Time to obfuscate: {:?}", obfuscation_time);
+        let sampler_uniform = DCRTPolyUniformSampler::new();
+        let sampler_hash = DCRTPolyHashSampler::<Keccak256>::new([0; 32]);
+        let sampler_trapdoor = DCRTPolyTrapdoorSampler::new(&params, SIGMA);
+        let mut rng = rand::rng();
+        let hardcoded_key = sampler_uniform.sample_poly(&params, &DistType::BitDist);
+        let obfuscation = obfuscate::<DCRTPolyMatrix, _, _, _, _>(
+            obf_params.clone(),
+            sampler_uniform,
+            sampler_hash,
+            sampler_trapdoor,
+            hardcoded_key.clone(),
+            &mut rng,
+        );
+        let obfuscation_time = start_time.elapsed();
+        info!("Time to obfuscate: {:?}", obfuscation_time);
 
-//         let bool_in = rng.random::<bool>();
-//         let input = [bool_in];
-//         let sampler_hash = DCRTPolyHashSampler::<Keccak256>::new([0; 32]);
-//         let output =
-//             obfuscation.eval::<_, DCRTPolyTrapdoorSampler>(obf_params, sampler_hash, &input);
-//         let total_time = start_time.elapsed();
-//         info!("hardcoded key {:?}", hardcoded_key.coeffs());
-//         info!("input {:?}", input);
-//         info!("output {:?}", output);
-//         info!("Time for evaluation: {:?}", total_time - obfuscation_time);
-//         info!("Total time: {:?}", total_time);
-//         let n = output.len() / 2;
-//         let output_1st_gate = output[..n].to_vec();
-//         let output_2nd_gate = output[n..].to_vec();
-//         let input_poly = DCRTPoly::from_const(
-//             &params,
-//             &FinRingElem::constant(&params.modulus(), bool_in as u64),
-//         );
-//         assert_eq!(output_1st_gate, (hardcoded_key.clone() * input_poly.clone()).to_bool_vec());
-//         assert_eq!(output_2nd_gate, (hardcoded_key * input_poly).to_bool_vec());
-//     }
-// }
+        let bool_in = rng.random::<bool>();
+        let input = [bool_in];
+        let sampler_hash = DCRTPolyHashSampler::<Keccak256>::new([0; 32]);
+        let output =
+            obfuscation.eval::<_, DCRTPolyTrapdoorSampler>(obf_params, sampler_hash, &input);
+        let total_time = start_time.elapsed();
+        info!("hardcoded key {:?}", hardcoded_key.coeffs());
+        info!("input {:?}", input);
+        info!("output {:?}", output);
+        info!("Time for evaluation: {:?}", total_time - obfuscation_time);
+        info!("Total time: {:?}", total_time);
+        let n = output.len() / 2;
+        let output_1st_gate = output[..n].to_vec();
+        let output_2nd_gate = output[n..].to_vec();
+        let input_poly = DCRTPoly::from_const(
+            &params,
+            &FinRingElem::constant(&params.modulus(), bool_in as u64),
+        );
+        assert_eq!(output_1st_gate, (hardcoded_key.clone() * input_poly.clone()).to_bool_vec());
+        assert_eq!(output_2nd_gate, (hardcoded_key * input_poly).to_bool_vec());
+    }
+}

--- a/tests/test_io_dummy_param.rs
+++ b/tests/test_io_dummy_param.rs
@@ -80,9 +80,6 @@ mod test {
         let output =
             obfuscation.eval::<_, DCRTPolyTrapdoorSampler>(obf_params, sampler_hash, &input);
         let total_time = start_time.elapsed();
-        info!("hardcoded key {:?}", hardcoded_key.coeffs());
-        info!("input {:?}", input);
-        info!("output {:?}", output);
         info!("Time for evaluation: {:?}", total_time - obfuscation_time);
         info!("Total time: {:?}", total_time);
         let n = output.len() / 2;

--- a/tests/test_io_dummy_param.rs
+++ b/tests/test_io_dummy_param.rs
@@ -1,98 +1,98 @@
-#[cfg(test)]
-mod test {
-    use diamond_io::{
-        bgg::circuit::PolyCircuit,
-        io::{obf::obfuscate, params::ObfuscationParams},
-        poly::{
-            dcrt::{
-                DCRTPoly, DCRTPolyHashSampler, DCRTPolyMatrix, DCRTPolyParams,
-                DCRTPolyTrapdoorSampler, DCRTPolyUniformSampler, FinRingElem,
-            },
-            sampler::DistType,
-            Poly, PolyElem, PolyParams,
-        },
-        utils::init_tracing,
-    };
-    use keccak_asm::Keccak256;
-    use num_bigint::BigUint;
-    use rand::Rng;
-    use std::sync::Arc;
-    use tracing::info;
+// #[cfg(test)]
+// mod test {
+//     use diamond_io::{
+//         bgg::circuit::PolyCircuit,
+//         io::{obf::obfuscate, params::ObfuscationParams},
+//         poly::{
+//             dcrt::{
+//                 DCRTPoly, DCRTPolyHashSampler, DCRTPolyMatrix, DCRTPolyParams,
+//                 DCRTPolyTrapdoorSampler, DCRTPolyUniformSampler, FinRingElem,
+//             },
+//             sampler::DistType,
+//             Poly, PolyElem, PolyParams,
+//         },
+//         utils::init_tracing,
+//     };
+//     use keccak_asm::Keccak256;
+//     use num_bigint::BigUint;
+//     use rand::Rng;
+//     use std::sync::Arc;
+//     use tracing::info;
 
-    const SIGMA: f64 = 4.578;
+//     const SIGMA: f64 = 4.578;
 
-    #[test]
-    fn test_io_just_mul_enc_and_and_bit() {
-        init_tracing();
-        let start_time = std::time::Instant::now();
-        let params = DCRTPolyParams::new(4, 2, 17, 10);
-        let log_q = params.modulus_bits();
-        let switched_modulus = Arc::new(BigUint::from(1u32));
-        let mut public_circuit = PolyCircuit::new();
+//     #[test]
+//     fn test_io_just_mul_enc_and_and_bit() {
+//         init_tracing();
+//         let start_time = std::time::Instant::now();
+//         let params = DCRTPolyParams::new(4, 2, 17, 10);
+//         let log_q = params.modulus_bits();
+//         let switched_modulus = Arc::new(BigUint::from(1u32));
+//         let mut public_circuit = PolyCircuit::new();
 
-        // inputs: BITS(ct), eval_input
-        // outputs: BITS(ct) AND eval_input, BITS(ct) AND eval_input
-        {
-            let inputs = public_circuit.input((2 * log_q) + 1);
-            let mut outputs = vec![];
-            let eval_input = inputs[2 * log_q];
-            for ct_input in inputs[0..2 * log_q].iter() {
-                let muled = public_circuit.and_gate(*ct_input, eval_input);
-                outputs.push(muled);
-            }
-            for ct_input in inputs[0..2 * log_q].iter() {
-                let muled = public_circuit.and_gate(*ct_input, eval_input);
-                outputs.push(muled);
-            }
-            public_circuit.output(outputs);
-        }
+//         // inputs: BITS(ct), eval_input
+//         // outputs: BITS(ct) AND eval_input, BITS(ct) AND eval_input
+//         {
+//             let inputs = public_circuit.input((2 * log_q) + 1);
+//             let mut outputs = vec![];
+//             let eval_input = inputs[2 * log_q];
+//             for ct_input in inputs[0..2 * log_q].iter() {
+//                 let muled = public_circuit.and_gate(*ct_input, eval_input);
+//                 outputs.push(muled);
+//             }
+//             for ct_input in inputs[0..2 * log_q].iter() {
+//                 let muled = public_circuit.and_gate(*ct_input, eval_input);
+//                 outputs.push(muled);
+//             }
+//             public_circuit.output(outputs);
+//         }
 
-        let obf_params = ObfuscationParams {
-            params: params.clone(),
-            switched_modulus,
-            input_size: 1,
-            public_circuit: public_circuit.clone(),
-            d: 3,
-            encoding_sigma: 0.0,
-            hardcoded_key_sigma: 0.0,
-            p_sigma: 0.0,
-        };
+//         let obf_params = ObfuscationParams {
+//             params: params.clone(),
+//             switched_modulus,
+//             input_size: 1,
+//             public_circuit: public_circuit.clone(),
+//             d: 3,
+//             encoding_sigma: 0.0,
+//             hardcoded_key_sigma: 0.0,
+//             p_sigma: 0.0,
+//         };
 
-        let sampler_uniform = DCRTPolyUniformSampler::new();
-        let sampler_hash = DCRTPolyHashSampler::<Keccak256>::new([0; 32]);
-        let sampler_trapdoor = DCRTPolyTrapdoorSampler::new(&params, SIGMA);
-        let mut rng = rand::rng();
-        let hardcoded_key = sampler_uniform.sample_poly(&params, &DistType::BitDist);
-        let obfuscation = obfuscate::<DCRTPolyMatrix, _, _, _, _>(
-            obf_params.clone(),
-            sampler_uniform,
-            sampler_hash,
-            sampler_trapdoor,
-            hardcoded_key.clone(),
-            &mut rng,
-        );
-        let obfuscation_time = start_time.elapsed();
-        info!("Time to obfuscate: {:?}", obfuscation_time);
+//         let sampler_uniform = DCRTPolyUniformSampler::new();
+//         let sampler_hash = DCRTPolyHashSampler::<Keccak256>::new([0; 32]);
+//         let sampler_trapdoor = DCRTPolyTrapdoorSampler::new(&params, SIGMA);
+//         let mut rng = rand::rng();
+//         let hardcoded_key = sampler_uniform.sample_poly(&params, &DistType::BitDist);
+//         let obfuscation = obfuscate::<DCRTPolyMatrix, _, _, _, _>(
+//             obf_params.clone(),
+//             sampler_uniform,
+//             sampler_hash,
+//             sampler_trapdoor,
+//             hardcoded_key.clone(),
+//             &mut rng,
+//         );
+//         let obfuscation_time = start_time.elapsed();
+//         info!("Time to obfuscate: {:?}", obfuscation_time);
 
-        let bool_in = rng.random::<bool>();
-        let input = [bool_in];
-        let sampler_hash = DCRTPolyHashSampler::<Keccak256>::new([0; 32]);
-        let output =
-            obfuscation.eval::<_, DCRTPolyTrapdoorSampler>(obf_params, sampler_hash, &input);
-        let total_time = start_time.elapsed();
-        info!("hardcoded key {:?}", hardcoded_key.coeffs());
-        info!("input {:?}", input);
-        info!("output {:?}", output);
-        info!("Time for evaluation: {:?}", total_time - obfuscation_time);
-        info!("Total time: {:?}", total_time);
-        let n = output.len() / 2;
-        let output_1st_gate = output[..n].to_vec();
-        let output_2nd_gate = output[n..].to_vec();
-        let input_poly = DCRTPoly::from_const(
-            &params,
-            &FinRingElem::constant(&params.modulus(), bool_in as u64),
-        );
-        assert_eq!(output_1st_gate, (hardcoded_key.clone() * input_poly.clone()).to_bool_vec());
-        assert_eq!(output_2nd_gate, (hardcoded_key * input_poly).to_bool_vec());
-    }
-}
+//         let bool_in = rng.random::<bool>();
+//         let input = [bool_in];
+//         let sampler_hash = DCRTPolyHashSampler::<Keccak256>::new([0; 32]);
+//         let output =
+//             obfuscation.eval::<_, DCRTPolyTrapdoorSampler>(obf_params, sampler_hash, &input);
+//         let total_time = start_time.elapsed();
+//         info!("hardcoded key {:?}", hardcoded_key.coeffs());
+//         info!("input {:?}", input);
+//         info!("output {:?}", output);
+//         info!("Time for evaluation: {:?}", total_time - obfuscation_time);
+//         info!("Total time: {:?}", total_time);
+//         let n = output.len() / 2;
+//         let output_1st_gate = output[..n].to_vec();
+//         let output_2nd_gate = output[n..].to_vec();
+//         let input_poly = DCRTPoly::from_const(
+//             &params,
+//             &FinRingElem::constant(&params.modulus(), bool_in as u64),
+//         );
+//         assert_eq!(output_1st_gate, (hardcoded_key.clone() * input_poly.clone()).to_bool_vec());
+//         assert_eq!(output_2nd_gate, (hardcoded_key * input_poly).to_bool_vec());
+//     }
+// }

--- a/tests/test_io_middle_param.rs
+++ b/tests/test_io_middle_param.rs
@@ -1,92 +1,92 @@
-#[cfg(test)]
-mod test {
-    use diamond_io::{
-        bgg::circuit::PolyCircuit,
-        io::{obf::obfuscate, params::ObfuscationParams},
-        poly::{
-            dcrt::{
-                DCRTPoly, DCRTPolyHashSampler, DCRTPolyMatrix, DCRTPolyParams,
-                DCRTPolyTrapdoorSampler, DCRTPolyUniformSampler, FinRingElem,
-            },
-            sampler::DistType,
-            Poly, PolyElem, PolyParams,
-        },
-        utils::init_tracing,
-    };
-    use keccak_asm::Keccak256;
-    use num_bigint::BigUint;
-    use num_traits::Num;
-    use rand::Rng;
-    use std::sync::Arc;
-    use tracing::info;
+// #[cfg(test)]
+// mod test {
+//     use diamond_io::{
+//         bgg::circuit::PolyCircuit,
+//         io::{obf::obfuscate, params::ObfuscationParams},
+//         poly::{
+//             dcrt::{
+//                 DCRTPoly, DCRTPolyHashSampler, DCRTPolyMatrix, DCRTPolyParams,
+//                 DCRTPolyTrapdoorSampler, DCRTPolyUniformSampler, FinRingElem,
+//             },
+//             sampler::DistType,
+//             Poly, PolyElem, PolyParams,
+//         },
+//         utils::init_tracing,
+//     };
+//     use keccak_asm::Keccak256;
+//     use num_bigint::BigUint;
+//     use num_traits::Num;
+//     use rand::Rng;
+//     use std::sync::Arc;
+//     use tracing::info;
 
-    const SIGMA: f64 = 4.578;
+//     const SIGMA: f64 = 4.578;
 
-    #[test]
-    #[ignore]
-    fn test_io_just_mul_enc_and_bit_middle_params() {
-        init_tracing();
-        let start_time = std::time::Instant::now();
-        let params = DCRTPolyParams::new(1024, 4, 37, 20);
-        let log_q = params.modulus_bits();
-        let switched_modulus = Arc::new(BigUint::from_str_radix("672178712", 10).unwrap());
-        let mut public_circuit = PolyCircuit::new();
+//     #[test]
+//     #[ignore]
+//     fn test_io_just_mul_enc_and_bit_middle_params() {
+//         init_tracing();
+//         let start_time = std::time::Instant::now();
+//         let params = DCRTPolyParams::new(1024, 4, 37, 20);
+//         let log_q = params.modulus_bits();
+//         let switched_modulus = Arc::new(BigUint::from_str_radix("672178712", 10).unwrap());
+//         let mut public_circuit = PolyCircuit::new();
 
-        // inputs: BITS(ct), eval_input
-        // outputs: BITS(ct) AND eval_input
-        {
-            let inputs = public_circuit.input((2 * log_q) + 1);
-            let mut outputs = vec![];
-            let eval_input = inputs[2 * log_q];
-            for ct_input in inputs[0..2 * log_q].iter() {
-                let muled = public_circuit.and_gate(*ct_input, eval_input);
-                outputs.push(muled);
-            }
-            public_circuit.output(outputs);
-        }
+//         // inputs: BITS(ct), eval_input
+//         // outputs: BITS(ct) AND eval_input
+//         {
+//             let inputs = public_circuit.input((2 * log_q) + 1);
+//             let mut outputs = vec![];
+//             let eval_input = inputs[2 * log_q];
+//             for ct_input in inputs[0..2 * log_q].iter() {
+//                 let muled = public_circuit.and_gate(*ct_input, eval_input);
+//                 outputs.push(muled);
+//             }
+//             public_circuit.output(outputs);
+//         }
 
-        let obf_params = ObfuscationParams {
-            params: params.clone(),
-            switched_modulus,
-            input_size: 1,
-            public_circuit: public_circuit.clone(),
-            d: 2,
-            encoding_sigma: 3.477984925390326e-48,
-            hardcoded_key_sigma: 7.754_896_427_200_485e16,
-            p_sigma: 1.550677652781115e-169,
-        };
+//         let obf_params = ObfuscationParams {
+//             params: params.clone(),
+//             switched_modulus,
+//             input_size: 1,
+//             public_circuit: public_circuit.clone(),
+//             d: 2,
+//             encoding_sigma: 3.477984925390326e-48,
+//             hardcoded_key_sigma: 7.754_896_427_200_485e16,
+//             p_sigma: 1.550677652781115e-169,
+//         };
 
-        let sampler_uniform = DCRTPolyUniformSampler::new();
-        let sampler_hash = DCRTPolyHashSampler::<Keccak256>::new([0; 32]);
-        let sampler_trapdoor = DCRTPolyTrapdoorSampler::new(&params, SIGMA);
-        let mut rng = rand::rng();
-        let hardcoded_key = sampler_uniform.sample_poly(&params, &DistType::BitDist);
-        let obfuscation = obfuscate::<DCRTPolyMatrix, _, _, _, _>(
-            obf_params.clone(),
-            sampler_uniform,
-            sampler_hash,
-            sampler_trapdoor,
-            hardcoded_key.clone(),
-            &mut rng,
-        );
-        let obfuscation_time = start_time.elapsed();
-        info!("Time to obfuscate: {:?}", obfuscation_time);
+//         let sampler_uniform = DCRTPolyUniformSampler::new();
+//         let sampler_hash = DCRTPolyHashSampler::<Keccak256>::new([0; 32]);
+//         let sampler_trapdoor = DCRTPolyTrapdoorSampler::new(&params, SIGMA);
+//         let mut rng = rand::rng();
+//         let hardcoded_key = sampler_uniform.sample_poly(&params, &DistType::BitDist);
+//         let obfuscation = obfuscate::<DCRTPolyMatrix, _, _, _, _>(
+//             obf_params.clone(),
+//             sampler_uniform,
+//             sampler_hash,
+//             sampler_trapdoor,
+//             hardcoded_key.clone(),
+//             &mut rng,
+//         );
+//         let obfuscation_time = start_time.elapsed();
+//         info!("Time to obfuscate: {:?}", obfuscation_time);
 
-        let bool_in = rng.random::<bool>();
-        let input = [bool_in];
-        let sampler_hash = DCRTPolyHashSampler::<Keccak256>::new([0; 32]);
-        let output =
-            obfuscation.eval::<_, DCRTPolyTrapdoorSampler>(obf_params, sampler_hash, &input);
-        let total_time = start_time.elapsed();
-        info!("hardcoded key {:?}", hardcoded_key.coeffs());
-        info!("input {:?}", input);
-        info!("output {:?}", output);
-        info!("Time for evaluation: {:?}", total_time - obfuscation_time);
-        info!("Total time: {:?}", total_time);
-        let input_poly = DCRTPoly::from_const(
-            &params,
-            &FinRingElem::constant(&params.modulus(), bool_in as u64),
-        );
-        assert_eq!(output, (hardcoded_key * input_poly).to_bool_vec());
-    }
-}
+//         let bool_in = rng.random::<bool>();
+//         let input = [bool_in];
+//         let sampler_hash = DCRTPolyHashSampler::<Keccak256>::new([0; 32]);
+//         let output =
+//             obfuscation.eval::<_, DCRTPolyTrapdoorSampler>(obf_params, sampler_hash, &input);
+//         let total_time = start_time.elapsed();
+//         info!("hardcoded key {:?}", hardcoded_key.coeffs());
+//         info!("input {:?}", input);
+//         info!("output {:?}", output);
+//         info!("Time for evaluation: {:?}", total_time - obfuscation_time);
+//         info!("Total time: {:?}", total_time);
+//         let input_poly = DCRTPoly::from_const(
+//             &params,
+//             &FinRingElem::constant(&params.modulus(), bool_in as u64),
+//         );
+//         assert_eq!(output, (hardcoded_key * input_poly).to_bool_vec());
+//     }
+// }

--- a/tests/test_io_middle_param.rs
+++ b/tests/test_io_middle_param.rs
@@ -78,9 +78,6 @@ mod test {
         let output =
             obfuscation.eval::<_, DCRTPolyTrapdoorSampler>(obf_params, sampler_hash, &input);
         let total_time = start_time.elapsed();
-        info!("hardcoded key {:?}", hardcoded_key.coeffs());
-        info!("input {:?}", input);
-        info!("output {:?}", output);
         info!("Time for evaluation: {:?}", total_time - obfuscation_time);
         info!("Total time: {:?}", total_time);
         let input_poly = DCRTPoly::from_const(

--- a/tests/test_io_middle_param.rs
+++ b/tests/test_io_middle_param.rs
@@ -1,92 +1,92 @@
-// #[cfg(test)]
-// mod test {
-//     use diamond_io::{
-//         bgg::circuit::PolyCircuit,
-//         io::{obf::obfuscate, params::ObfuscationParams},
-//         poly::{
-//             dcrt::{
-//                 DCRTPoly, DCRTPolyHashSampler, DCRTPolyMatrix, DCRTPolyParams,
-//                 DCRTPolyTrapdoorSampler, DCRTPolyUniformSampler, FinRingElem,
-//             },
-//             sampler::DistType,
-//             Poly, PolyElem, PolyParams,
-//         },
-//         utils::init_tracing,
-//     };
-//     use keccak_asm::Keccak256;
-//     use num_bigint::BigUint;
-//     use num_traits::Num;
-//     use rand::Rng;
-//     use std::sync::Arc;
-//     use tracing::info;
+#[cfg(test)]
+mod test {
+    use diamond_io::{
+        bgg::circuit::PolyCircuit,
+        io::{obf::obfuscate, params::ObfuscationParams},
+        poly::{
+            dcrt::{
+                DCRTPoly, DCRTPolyHashSampler, DCRTPolyMatrix, DCRTPolyParams,
+                DCRTPolyTrapdoorSampler, DCRTPolyUniformSampler, FinRingElem,
+            },
+            sampler::DistType,
+            Poly, PolyElem, PolyParams,
+        },
+        utils::init_tracing,
+    };
+    use keccak_asm::Keccak256;
+    use num_bigint::BigUint;
+    use num_traits::Num;
+    use rand::Rng;
+    use std::sync::Arc;
+    use tracing::info;
 
-//     const SIGMA: f64 = 4.578;
+    const SIGMA: f64 = 4.578;
 
-//     #[test]
-//     #[ignore]
-//     fn test_io_just_mul_enc_and_bit_middle_params() {
-//         init_tracing();
-//         let start_time = std::time::Instant::now();
-//         let params = DCRTPolyParams::new(1024, 4, 37, 20);
-//         let log_q = params.modulus_bits();
-//         let switched_modulus = Arc::new(BigUint::from_str_radix("672178712", 10).unwrap());
-//         let mut public_circuit = PolyCircuit::new();
+    #[test]
+    #[ignore]
+    fn test_io_just_mul_enc_and_bit_middle_params() {
+        init_tracing();
+        let start_time = std::time::Instant::now();
+        let params = DCRTPolyParams::new(1024, 4, 37, 20);
+        let log_q = params.modulus_bits();
+        let switched_modulus = Arc::new(BigUint::from_str_radix("672178712", 10).unwrap());
+        let mut public_circuit = PolyCircuit::new();
 
-//         // inputs: BITS(ct), eval_input
-//         // outputs: BITS(ct) AND eval_input
-//         {
-//             let inputs = public_circuit.input((2 * log_q) + 1);
-//             let mut outputs = vec![];
-//             let eval_input = inputs[2 * log_q];
-//             for ct_input in inputs[0..2 * log_q].iter() {
-//                 let muled = public_circuit.and_gate(*ct_input, eval_input);
-//                 outputs.push(muled);
-//             }
-//             public_circuit.output(outputs);
-//         }
+        // inputs: BITS(ct), eval_input
+        // outputs: BITS(ct) AND eval_input
+        {
+            let inputs = public_circuit.input((2 * log_q) + 1);
+            let mut outputs = vec![];
+            let eval_input = inputs[2 * log_q];
+            for ct_input in inputs[0..2 * log_q].iter() {
+                let muled = public_circuit.and_gate(*ct_input, eval_input);
+                outputs.push(muled);
+            }
+            public_circuit.output(outputs);
+        }
 
-//         let obf_params = ObfuscationParams {
-//             params: params.clone(),
-//             switched_modulus,
-//             input_size: 1,
-//             public_circuit: public_circuit.clone(),
-//             d: 2,
-//             encoding_sigma: 3.477984925390326e-48,
-//             hardcoded_key_sigma: 7.754_896_427_200_485e16,
-//             p_sigma: 1.550677652781115e-169,
-//         };
+        let obf_params = ObfuscationParams {
+            params: params.clone(),
+            switched_modulus,
+            input_size: 1,
+            public_circuit: public_circuit.clone(),
+            d: 2,
+            encoding_sigma: 3.477984925390326e-48,
+            hardcoded_key_sigma: 7.754_896_427_200_485e16,
+            p_sigma: 1.550677652781115e-169,
+        };
 
-//         let sampler_uniform = DCRTPolyUniformSampler::new();
-//         let sampler_hash = DCRTPolyHashSampler::<Keccak256>::new([0; 32]);
-//         let sampler_trapdoor = DCRTPolyTrapdoorSampler::new(&params, SIGMA);
-//         let mut rng = rand::rng();
-//         let hardcoded_key = sampler_uniform.sample_poly(&params, &DistType::BitDist);
-//         let obfuscation = obfuscate::<DCRTPolyMatrix, _, _, _, _>(
-//             obf_params.clone(),
-//             sampler_uniform,
-//             sampler_hash,
-//             sampler_trapdoor,
-//             hardcoded_key.clone(),
-//             &mut rng,
-//         );
-//         let obfuscation_time = start_time.elapsed();
-//         info!("Time to obfuscate: {:?}", obfuscation_time);
+        let sampler_uniform = DCRTPolyUniformSampler::new();
+        let sampler_hash = DCRTPolyHashSampler::<Keccak256>::new([0; 32]);
+        let sampler_trapdoor = DCRTPolyTrapdoorSampler::new(&params, SIGMA);
+        let mut rng = rand::rng();
+        let hardcoded_key = sampler_uniform.sample_poly(&params, &DistType::BitDist);
+        let obfuscation = obfuscate::<DCRTPolyMatrix, _, _, _, _>(
+            obf_params.clone(),
+            sampler_uniform,
+            sampler_hash,
+            sampler_trapdoor,
+            hardcoded_key.clone(),
+            &mut rng,
+        );
+        let obfuscation_time = start_time.elapsed();
+        info!("Time to obfuscate: {:?}", obfuscation_time);
 
-//         let bool_in = rng.random::<bool>();
-//         let input = [bool_in];
-//         let sampler_hash = DCRTPolyHashSampler::<Keccak256>::new([0; 32]);
-//         let output =
-//             obfuscation.eval::<_, DCRTPolyTrapdoorSampler>(obf_params, sampler_hash, &input);
-//         let total_time = start_time.elapsed();
-//         info!("hardcoded key {:?}", hardcoded_key.coeffs());
-//         info!("input {:?}", input);
-//         info!("output {:?}", output);
-//         info!("Time for evaluation: {:?}", total_time - obfuscation_time);
-//         info!("Total time: {:?}", total_time);
-//         let input_poly = DCRTPoly::from_const(
-//             &params,
-//             &FinRingElem::constant(&params.modulus(), bool_in as u64),
-//         );
-//         assert_eq!(output, (hardcoded_key * input_poly).to_bool_vec());
-//     }
-// }
+        let bool_in = rng.random::<bool>();
+        let input = [bool_in];
+        let sampler_hash = DCRTPolyHashSampler::<Keccak256>::new([0; 32]);
+        let output =
+            obfuscation.eval::<_, DCRTPolyTrapdoorSampler>(obf_params, sampler_hash, &input);
+        let total_time = start_time.elapsed();
+        info!("hardcoded key {:?}", hardcoded_key.coeffs());
+        info!("input {:?}", input);
+        info!("output {:?}", output);
+        info!("Time for evaluation: {:?}", total_time - obfuscation_time);
+        info!("Total time: {:?}", total_time);
+        let input_poly = DCRTPoly::from_const(
+            &params,
+            &FinRingElem::constant(&params.modulus(), bool_in as u64),
+        );
+        assert_eq!(output, (hardcoded_key * input_poly).to_bool_vec());
+    }
+}

--- a/tests/test_io_real_param.rs
+++ b/tests/test_io_real_param.rs
@@ -1,92 +1,94 @@
-#[cfg(test)]
-mod test {
-    use diamond_io::{
-        bgg::circuit::PolyCircuit,
-        io::{obf::obfuscate, params::ObfuscationParams},
-        poly::{
-            dcrt::{
-                DCRTPoly, DCRTPolyHashSampler, DCRTPolyMatrix, DCRTPolyParams,
-                DCRTPolyTrapdoorSampler, DCRTPolyUniformSampler, FinRingElem,
-            },
-            sampler::DistType,
-            Poly, PolyElem, PolyParams,
-        },
-        utils::init_tracing,
-    };
-    use keccak_asm::Keccak256;
-    use num_bigint::BigUint;
-    use num_traits::Num;
-    use rand::Rng;
-    use std::sync::Arc;
-    use tracing::info;
+// #[cfg(test)]
+// mod test {
+//     use diamond_io::{
+//         bgg::circuit::PolyCircuit,
+//         io::{obf::obfuscate, params::ObfuscationParams},
+//         poly::{
+//             dcrt::{
+//                 DCRTPoly, DCRTPolyHashSampler, DCRTPolyMatrix, DCRTPolyParams,
+//                 DCRTPolyTrapdoorSampler, DCRTPolyUniformSampler, FinRingElem,
+//             },
+//             sampler::DistType,
+//             Poly, PolyElem, PolyParams,
+//         },
+//         utils::init_tracing,
+//     };
+//     use keccak_asm::Keccak256;
+//     use num_bigint::BigUint;
+//     use num_traits::Num;
+//     use rand::Rng;
+//     use std::sync::Arc;
+//     use tracing::info;
 
-    const SIGMA: f64 = 4.578;
+//     const SIGMA: f64 = 4.578;
 
-    #[test]
-    #[ignore]
-    fn test_io_just_mul_enc_and_bit_real_params() {
-        init_tracing();
-        let start_time = std::time::Instant::now();
-        let params = DCRTPolyParams::new(8192, 12, 51, 16);
-        let log_q = params.modulus_bits();
-        let switched_modulus = Arc::new(BigUint::from_str_radix("15829145694278690179872161345257420162248406342477557754500035589945422364945084658438108187108114830000000000000000000000000000000000000000000000000000000000000000000000000000", 10).unwrap());
-        let mut public_circuit = PolyCircuit::new();
+//     #[test]
+//     #[ignore]
+//     fn test_io_just_mul_enc_and_bit_real_params() {
+//         init_tracing();
+//         let start_time = std::time::Instant::now();
+//         let params = DCRTPolyParams::new(8192, 12, 51, 16);
+//         let log_q = params.modulus_bits();
+//         let switched_modulus =
+// Arc::new(BigUint::from_str_radix("
+// 15829145694278690179872161345257420162248406342477557754500035589945422364945084658438108187108114830000000000000000000000000000000000000000000000000000000000000000000000000000"
+// , 10).unwrap());         let mut public_circuit = PolyCircuit::new();
 
-        // inputs: BITS(ct), eval_input
-        // outputs: BITS(ct) AND eval_input
-        {
-            let inputs = public_circuit.input((2 * log_q) + 1);
-            let mut outputs = vec![];
-            let eval_input = inputs[2 * log_q];
-            for ct_input in inputs[0..2 * log_q].iter() {
-                let muled = public_circuit.and_gate(*ct_input, eval_input);
-                outputs.push(muled);
-            }
-            public_circuit.output(outputs);
-        }
+//         // inputs: BITS(ct), eval_input
+//         // outputs: BITS(ct) AND eval_input
+//         {
+//             let inputs = public_circuit.input((2 * log_q) + 1);
+//             let mut outputs = vec![];
+//             let eval_input = inputs[2 * log_q];
+//             for ct_input in inputs[0..2 * log_q].iter() {
+//                 let muled = public_circuit.and_gate(*ct_input, eval_input);
+//                 outputs.push(muled);
+//             }
+//             public_circuit.output(outputs);
+//         }
 
-        let obf_params = ObfuscationParams {
-            params: params.clone(),
-            switched_modulus,
-            input_size: 1,
-            public_circuit: public_circuit.clone(),
-            d: 1,
-            encoding_sigma: 7.26009020373352e+51,
-            hardcoded_key_sigma: 4.652_550_537_829_127e102,
-            p_sigma: 2.9297574882928115,
-        };
+//         let obf_params = ObfuscationParams {
+//             params: params.clone(),
+//             switched_modulus,
+//             input_size: 1,
+//             public_circuit: public_circuit.clone(),
+//             d: 1,
+//             encoding_sigma: 7.26009020373352e+51,
+//             hardcoded_key_sigma: 4.652_550_537_829_127e102,
+//             p_sigma: 2.9297574882928115,
+//         };
 
-        let sampler_uniform = DCRTPolyUniformSampler::new();
-        let sampler_hash = DCRTPolyHashSampler::<Keccak256>::new([0; 32]);
-        let sampler_trapdoor = DCRTPolyTrapdoorSampler::new(&params, SIGMA);
-        let mut rng = rand::rng();
-        let hardcoded_key = sampler_uniform.sample_poly(&params, &DistType::BitDist);
-        let obfuscation = obfuscate::<DCRTPolyMatrix, _, _, _, _>(
-            obf_params.clone(),
-            sampler_uniform,
-            sampler_hash,
-            sampler_trapdoor,
-            hardcoded_key.clone(),
-            &mut rng,
-        );
-        let obfuscation_time = start_time.elapsed();
-        info!("Time to obfuscate: {:?}", obfuscation_time);
+//         let sampler_uniform = DCRTPolyUniformSampler::new();
+//         let sampler_hash = DCRTPolyHashSampler::<Keccak256>::new([0; 32]);
+//         let sampler_trapdoor = DCRTPolyTrapdoorSampler::new(&params, SIGMA);
+//         let mut rng = rand::rng();
+//         let hardcoded_key = sampler_uniform.sample_poly(&params, &DistType::BitDist);
+//         let obfuscation = obfuscate::<DCRTPolyMatrix, _, _, _, _>(
+//             obf_params.clone(),
+//             sampler_uniform,
+//             sampler_hash,
+//             sampler_trapdoor,
+//             hardcoded_key.clone(),
+//             &mut rng,
+//         );
+//         let obfuscation_time = start_time.elapsed();
+//         info!("Time to obfuscate: {:?}", obfuscation_time);
 
-        let bool_in = rng.random::<bool>();
-        let input = [bool_in];
-        let sampler_hash = DCRTPolyHashSampler::<Keccak256>::new([0; 32]);
-        let output =
-            obfuscation.eval::<_, DCRTPolyTrapdoorSampler>(obf_params, sampler_hash, &input);
-        let total_time = start_time.elapsed();
-        info!("hardcoded key {:?}", hardcoded_key.coeffs());
-        info!("input {:?}", input);
-        info!("output {:?}", output);
-        info!("Time for evaluation: {:?}", total_time - obfuscation_time);
-        info!("Total time: {:?}", total_time);
-        let input_poly = DCRTPoly::from_const(
-            &params,
-            &FinRingElem::constant(&params.modulus(), bool_in as u64),
-        );
-        assert_eq!(output, (hardcoded_key * input_poly).to_bool_vec());
-    }
-}
+//         let bool_in = rng.random::<bool>();
+//         let input = [bool_in];
+//         let sampler_hash = DCRTPolyHashSampler::<Keccak256>::new([0; 32]);
+//         let output =
+//             obfuscation.eval::<_, DCRTPolyTrapdoorSampler>(obf_params, sampler_hash, &input);
+//         let total_time = start_time.elapsed();
+//         info!("hardcoded key {:?}", hardcoded_key.coeffs());
+//         info!("input {:?}", input);
+//         info!("output {:?}", output);
+//         info!("Time for evaluation: {:?}", total_time - obfuscation_time);
+//         info!("Total time: {:?}", total_time);
+//         let input_poly = DCRTPoly::from_const(
+//             &params,
+//             &FinRingElem::constant(&params.modulus(), bool_in as u64),
+//         );
+//         assert_eq!(output, (hardcoded_key * input_poly).to_bool_vec());
+//     }
+// }

--- a/tests/test_io_real_param.rs
+++ b/tests/test_io_real_param.rs
@@ -81,9 +81,6 @@ Arc::new(BigUint::from_str_radix("
         let output =
             obfuscation.eval::<_, DCRTPolyTrapdoorSampler>(obf_params, sampler_hash, &input);
         let total_time = start_time.elapsed();
-        info!("hardcoded key {:?}", hardcoded_key.coeffs());
-        info!("input {:?}", input);
-        info!("output {:?}", output);
         info!("Time for evaluation: {:?}", total_time - obfuscation_time);
         info!("Total time: {:?}", total_time);
         let input_poly = DCRTPoly::from_const(

--- a/tests/test_io_real_param.rs
+++ b/tests/test_io_real_param.rs
@@ -1,94 +1,95 @@
-// #[cfg(test)]
-// mod test {
-//     use diamond_io::{
-//         bgg::circuit::PolyCircuit,
-//         io::{obf::obfuscate, params::ObfuscationParams},
-//         poly::{
-//             dcrt::{
-//                 DCRTPoly, DCRTPolyHashSampler, DCRTPolyMatrix, DCRTPolyParams,
-//                 DCRTPolyTrapdoorSampler, DCRTPolyUniformSampler, FinRingElem,
-//             },
-//             sampler::DistType,
-//             Poly, PolyElem, PolyParams,
-//         },
-//         utils::init_tracing,
-//     };
-//     use keccak_asm::Keccak256;
-//     use num_bigint::BigUint;
-//     use num_traits::Num;
-//     use rand::Rng;
-//     use std::sync::Arc;
-//     use tracing::info;
+#[cfg(test)]
+mod test {
+    use diamond_io::{
+        bgg::circuit::PolyCircuit,
+        io::{obf::obfuscate, params::ObfuscationParams},
+        poly::{
+            dcrt::{
+                DCRTPoly, DCRTPolyHashSampler, DCRTPolyMatrix, DCRTPolyParams,
+                DCRTPolyTrapdoorSampler, DCRTPolyUniformSampler, FinRingElem,
+            },
+            sampler::DistType,
+            Poly, PolyElem, PolyParams,
+        },
+        utils::init_tracing,
+    };
+    use keccak_asm::Keccak256;
+    use num_bigint::BigUint;
+    use num_traits::Num;
+    use rand::Rng;
+    use std::sync::Arc;
+    use tracing::info;
 
-//     const SIGMA: f64 = 4.578;
+    const SIGMA: f64 = 4.578;
 
-//     #[test]
-//     #[ignore]
-//     fn test_io_just_mul_enc_and_bit_real_params() {
-//         init_tracing();
-//         let start_time = std::time::Instant::now();
-//         let params = DCRTPolyParams::new(8192, 12, 51, 16);
-//         let log_q = params.modulus_bits();
-//         let switched_modulus =
-// Arc::new(BigUint::from_str_radix("
-// 15829145694278690179872161345257420162248406342477557754500035589945422364945084658438108187108114830000000000000000000000000000000000000000000000000000000000000000000000000000"
-// , 10).unwrap());         let mut public_circuit = PolyCircuit::new();
+    #[test]
+    #[ignore]
+    fn test_io_just_mul_enc_and_bit_real_params() {
+        init_tracing();
+        let start_time = std::time::Instant::now();
+        let params = DCRTPolyParams::new(8192, 12, 51, 16);
+        let log_q = params.modulus_bits();
+        let switched_modulus =
+Arc::new(BigUint::from_str_radix("
+15829145694278690179872161345257420162248406342477557754500035589945422364945084658438108187108114830000000000000000000000000000000000000000000000000000000000000000000000000000"
+, 10).unwrap());
+        let mut public_circuit = PolyCircuit::new();
 
-//         // inputs: BITS(ct), eval_input
-//         // outputs: BITS(ct) AND eval_input
-//         {
-//             let inputs = public_circuit.input((2 * log_q) + 1);
-//             let mut outputs = vec![];
-//             let eval_input = inputs[2 * log_q];
-//             for ct_input in inputs[0..2 * log_q].iter() {
-//                 let muled = public_circuit.and_gate(*ct_input, eval_input);
-//                 outputs.push(muled);
-//             }
-//             public_circuit.output(outputs);
-//         }
+        // inputs: BITS(ct), eval_input
+        // outputs: BITS(ct) AND eval_input
+        {
+            let inputs = public_circuit.input((2 * log_q) + 1);
+            let mut outputs = vec![];
+            let eval_input = inputs[2 * log_q];
+            for ct_input in inputs[0..2 * log_q].iter() {
+                let muled = public_circuit.and_gate(*ct_input, eval_input);
+                outputs.push(muled);
+            }
+            public_circuit.output(outputs);
+        }
 
-//         let obf_params = ObfuscationParams {
-//             params: params.clone(),
-//             switched_modulus,
-//             input_size: 1,
-//             public_circuit: public_circuit.clone(),
-//             d: 1,
-//             encoding_sigma: 7.26009020373352e+51,
-//             hardcoded_key_sigma: 4.652_550_537_829_127e102,
-//             p_sigma: 2.9297574882928115,
-//         };
+        let obf_params = ObfuscationParams {
+            params: params.clone(),
+            switched_modulus,
+            input_size: 1,
+            public_circuit: public_circuit.clone(),
+            d: 1,
+            encoding_sigma: 7.26009020373352e+51,
+            hardcoded_key_sigma: 4.652_550_537_829_127e102,
+            p_sigma: 2.9297574882928115,
+        };
 
-//         let sampler_uniform = DCRTPolyUniformSampler::new();
-//         let sampler_hash = DCRTPolyHashSampler::<Keccak256>::new([0; 32]);
-//         let sampler_trapdoor = DCRTPolyTrapdoorSampler::new(&params, SIGMA);
-//         let mut rng = rand::rng();
-//         let hardcoded_key = sampler_uniform.sample_poly(&params, &DistType::BitDist);
-//         let obfuscation = obfuscate::<DCRTPolyMatrix, _, _, _, _>(
-//             obf_params.clone(),
-//             sampler_uniform,
-//             sampler_hash,
-//             sampler_trapdoor,
-//             hardcoded_key.clone(),
-//             &mut rng,
-//         );
-//         let obfuscation_time = start_time.elapsed();
-//         info!("Time to obfuscate: {:?}", obfuscation_time);
+        let sampler_uniform = DCRTPolyUniformSampler::new();
+        let sampler_hash = DCRTPolyHashSampler::<Keccak256>::new([0; 32]);
+        let sampler_trapdoor = DCRTPolyTrapdoorSampler::new(&params, SIGMA);
+        let mut rng = rand::rng();
+        let hardcoded_key = sampler_uniform.sample_poly(&params, &DistType::BitDist);
+        let obfuscation = obfuscate::<DCRTPolyMatrix, _, _, _, _>(
+            obf_params.clone(),
+            sampler_uniform,
+            sampler_hash,
+            sampler_trapdoor,
+            hardcoded_key.clone(),
+            &mut rng,
+        );
+        let obfuscation_time = start_time.elapsed();
+        info!("Time to obfuscate: {:?}", obfuscation_time);
 
-//         let bool_in = rng.random::<bool>();
-//         let input = [bool_in];
-//         let sampler_hash = DCRTPolyHashSampler::<Keccak256>::new([0; 32]);
-//         let output =
-//             obfuscation.eval::<_, DCRTPolyTrapdoorSampler>(obf_params, sampler_hash, &input);
-//         let total_time = start_time.elapsed();
-//         info!("hardcoded key {:?}", hardcoded_key.coeffs());
-//         info!("input {:?}", input);
-//         info!("output {:?}", output);
-//         info!("Time for evaluation: {:?}", total_time - obfuscation_time);
-//         info!("Total time: {:?}", total_time);
-//         let input_poly = DCRTPoly::from_const(
-//             &params,
-//             &FinRingElem::constant(&params.modulus(), bool_in as u64),
-//         );
-//         assert_eq!(output, (hardcoded_key * input_poly).to_bool_vec());
-//     }
-// }
+        let bool_in = rng.random::<bool>();
+        let input = [bool_in];
+        let sampler_hash = DCRTPolyHashSampler::<Keccak256>::new([0; 32]);
+        let output =
+            obfuscation.eval::<_, DCRTPolyTrapdoorSampler>(obf_params, sampler_hash, &input);
+        let total_time = start_time.elapsed();
+        info!("hardcoded key {:?}", hardcoded_key.coeffs());
+        info!("input {:?}", input);
+        info!("output {:?}", output);
+        info!("Time for evaluation: {:?}", total_time - obfuscation_time);
+        info!("Total time: {:?}", total_time);
+        let input_poly = DCRTPoly::from_const(
+            &params,
+            &FinRingElem::constant(&params.modulus(), bool_in as u64),
+        );
+        assert_eq!(output, (hardcoded_key * input_poly).to_bool_vec());
+    }
+}


### PR DESCRIPTION
In order to decrypt a ciphertext defined as `a_bit_0, b_bit_0, a_bit_1, b_bit_1, ..., a_bit_logq-1, b_bit_logq-1` the current implementation executes a circuit that performs, for each pair `a_bit, b_bit` the following inner product operation:

`a_bit * t_bar + b_bit * -1` which, overall, accounts for `2*log_q` multiplication gates per ciphertext.

In this proposed PR, the logic has been modified to directly pass `-t_bar` as circuit input and perform the operation `a_bit * -t_bar + b_bit` resulting in `log_q` multiplication gates per ciphertext.

At the same time, we had to modify the sign in the `rlwe_encrypt` logic

from 

```
    b = t * a + e - (m * scale)
```

to 

```
    b = t * a + e + (m * scale)
```

## Benches

Benchmarks calculated on `uv run memory_profile.py cargo test -r --test test_io_middle_param --no-default-features -- --ignored`

`main`

```
Time to obfuscate: 348.691209709s
Time for evaluation: 314.686266083s
Total time: 663.377475792s
```

```
===== PHYSICAL MEMORY USAGE =====

Step Description                                                       Memory Usage    Absolute Change      % Change       
------------------------------------------------------------------------------------------------------------------------
Sampled public data                                                    17.94 MB        0.0 B                0.00%
Sampled pub key init                                                   26.55 MB        8.61 MB              48.00%
Sampled s_bars                                                         26.56 MB        16.00 KB             0.06%
Sampled t_bar_matrix                                                   26.59 MB        32.00 KB             0.12%
Sampled hardcoded_key_matrix                                           26.59 MB        0.0 B                0.00%
Generated RLWE ciphertext {a, b}                                       26.66 MB        64.00 KB             0.24%
Decomposed RLWE ciphertext into {bits(a), bits(b)}                     36.09 MB        9.44 MB              35.40%
Sampled initial encodings                                              45.22 MB        9.12 MB              25.28%
b star trapdoor init sampled                                           76.14 MB        30.92 MB             68.38%
Computed p_init                                                        76.14 MB        0.0 B                0.00%
Computed u_0, u_1, u_star                                              76.14 MB        0.0 B                0.00%
Sampled b_star trapdoor for idx                                        107.41 MB       31.27 MB             41.06%
Sampled pub key idx                                                    109.12 MB       1.72 MB              1.60%
Sampled b trapdoor for idx and bit                                     151.66 MB       42.53 MB             38.97%
preimage parameters computed                                           154.80 MB       3.14 MB              2.07%
p_hat generated                                                        477.88 MB       323.08 MB            208.71%
z_hat_mat generated                                                    501.61 MB       23.73 MB             4.97%
z_hat generated                                                        556.31 MB       54.70 MB             10.91%
Computed m_preimage_bit                                                528.06 MB       -29622272.0 B        -5.08%
preimage parameters computed                                           528.06 MB       0.0 B                0.00%
p_hat generated                                                        630.45 MB       102.39 MB            19.39%
z_hat_mat generated                                                    649.50 MB       19.05 MB             3.02%
z_hat generated                                                        685.47 MB       35.97 MB             5.54%
Computed n_preimage_bit                                                644.61 MB       -42844160.0 B        -5.96%
preimage parameters computed                                           645.92 MB       1.31 MB              0.20%
p_hat generated                                                        798.11 MB       152.19 MB            23.56%
z_hat_mat generated                                                    814.53 MB       16.42 MB             2.06%
z_hat generated                                                        867.44 MB       52.91 MB             6.50%
Computed k_preimage_bit                                                823.84 MB       -45711360.0 B        -5.03%
Sampled b trapdoor for idx and bit                                     825.67 MB       1.83 MB              0.22%
preimage parameters computed                                           826.33 MB       672.00 KB            0.08%
p_hat generated                                                        912.28 MB       85.95 MB             10.40%
z_hat_mat generated                                                    913.94 MB       1.66 MB              0.18%
z_hat generated                                                        941.45 MB       27.52 MB             3.01%
Computed m_preimage_bit                                                916.64 MB       -26017792.0 B        -2.64%
preimage parameters computed                                           916.64 MB       0.0 B                0.00%
p_hat generated                                                        1009.34 MB      92.70 MB             10.11%
z_hat_mat generated                                                    1012.39 MB      3.05 MB              0.30%
z_hat generated                                                        1.03 GB         42.83 MB             4.23%
Computed n_preimage_bit                                                1.01 GB         -19431424.0 B        -1.76%
preimage parameters computed                                           1.01 GB         0.0 B                0.00%
p_hat generated                                                        1.13 GB         122.20 MB            11.79%
z_hat_mat generated                                                    1.14 GB         11.77 MB             1.02%
z_hat generated                                                        1.22 GB         75.92 MB             6.49%
Computed k_preimage_bit                                                1.21 GB         -8601600.0 B         -0.66%
Computed final_circuit                                                 1.19 GB         -16777216.0 B        -1.29%
Evaluated outputs                                                      3.20 GB         2.01 GB              168.16%
Computed final_preimage_target                                         1.32 GB         -2022965248.0 B      -58.86%
preimage parameters computed                                           1.32 GB         0.0 B                0.00%
p_hat generated                                                        1.32 GB         720.00 KB            0.05%
z_hat_mat generated                                                    1.32 GB         0.0 B                0.00%
z_hat generated                                                        1.32 GB         0.0 B                0.00%
Sampled final_preimage                                                 1.32 GB         0.0 B                0.00%

===== SUMMARY =====
Initial physical memory: 17.94 MB
Final physical memory: 1.32 GB
Peak physical memory: 3.20 GB
Total physical memory increase: 1.30 GB
```

`feat/optimize_ip_circuit_2`

```
Time to obfuscate: 274.506186791s
Time for evaluation: 233.976892709s
Total time: 508.4830795s
```

```
===== PHYSICAL MEMORY USAGE =====

Step Description                                                       Memory Usage    Absolute Change      % Change       
------------------------------------------------------------------------------------------------------------------------
Sampled public data                                                    18.11 MB        0.0 B                0.00%
Sampled pub key init                                                   26.86 MB        8.75 MB              48.32%
Sampled s_bars                                                         26.88 MB        16.00 KB             0.06%
Sampled t_bar_matrix                                                   26.88 MB        0.0 B                0.00%
Sampled hardcoded_key_matrix                                           26.88 MB        0.0 B                0.00%
Generated RLWE ciphertext {a, b}                                       26.91 MB        32.00 KB             0.12%
Decomposed RLWE ciphertext into {bits(a), bits(b)}                     36.00 MB        9.09 MB              33.80%
Sampled initial encodings                                              45.08 MB        9.08 MB              25.22%
b star trapdoor init sampled                                           76.25 MB        31.17 MB             69.15%
Computed p_init                                                        76.25 MB        0.0 B                0.00%
Computed u_0, u_1, u_star                                              76.25 MB        0.0 B                0.00%
Sampled b_star trapdoor for idx                                        107.36 MB       31.11 MB             40.80%
Sampled pub key idx                                                    109.03 MB       1.67 MB              1.56%
Sampled b trapdoor for idx and bit                                     150.92 MB       41.89 MB             38.42%
preimage parameters computed                                           152.83 MB       1.91 MB              1.26%
p_hat generated                                                        491.56 MB       338.73 MB            221.64%
z_hat_mat generated                                                    501.78 MB       10.22 MB             2.08%
z_hat generated                                                        544.45 MB       42.67 MB             8.50%
Computed m_preimage_bit                                                518.42 MB       -27295744.0 B        -4.78%
preimage parameters computed                                           519.58 MB       1.16 MB              0.22%
p_hat generated                                                        612.17 MB       92.59 MB             17.82%
z_hat_mat generated                                                    640.89 MB       28.72 MB             4.69%
z_hat generated                                                        673.52 MB       32.62 MB             5.09%
Computed n_preimage_bit                                                630.61 MB       -44990464.0 B        -6.37%
preimage parameters computed                                           631.41 MB       816.00 KB            0.13%
p_hat generated                                                        778.41 MB       147.00 MB            23.28%
z_hat_mat generated                                                    786.62 MB       8.22 MB              1.06%
z_hat generated                                                        851.86 MB       65.23 MB             8.29%
Computed k_preimage_bit                                                830.89 MB       -21987328.0 B        -2.46%
Sampled b trapdoor for idx and bit                                     816.23 MB       -15368192.0 B        -1.76%
preimage parameters computed                                           816.30 MB       64.00 KB             0.01%
p_hat generated                                                        904.31 MB       88.02 MB             10.78%
z_hat_mat generated                                                    907.08 MB       2.77 MB              0.31%
z_hat generated                                                        941.00 MB       33.92 MB             3.74%
Computed m_preimage_bit                                                915.67 MB       -26558464.0 B        -2.69%
preimage parameters computed                                           915.67 MB       0.0 B                0.00%
p_hat generated                                                        1006.28 MB      90.61 MB             9.90%
z_hat_mat generated                                                    1.00 GB         19.92 MB             1.98%
z_hat generated                                                        1.03 GB         28.97 MB             2.82%
Computed n_preimage_bit                                                1.01 GB         -20873216.0 B        -1.89%
preimage parameters computed                                           1.01 GB         0.0 B                0.00%
p_hat generated                                                        1.13 GB         122.56 MB            11.84%
z_hat_mat generated                                                    1.15 GB         24.62 MB             2.13%
z_hat generated                                                        1.21 GB         52.78 MB             4.46%
Computed k_preimage_bit                                                1.20 GB         -10403840.0 B        -0.80%
Computed final_circuit                                                 1.20 GB         0.0 B                0.00%
Evaluated outputs                                                      2.86 GB         1.67 GB              139.19%
Computed final_preimage_target                                         1.29 GB         -1692090368.0 B      -55.06%
preimage parameters computed                                           1.29 GB         0.0 B                0.00%
p_hat generated                                                        1.29 GB         224.00 KB            0.02%
z_hat_mat generated                                                    1.29 GB         0.0 B                0.00%
z_hat generated                                                        1.29 GB         0.0 B                0.00%
Sampled final_preimage                                                 1.29 GB         0.0 B                0.00%

===== SUMMARY =====
Initial physical memory: 18.11 MB
Final physical memory: 1.29 GB
Peak physical memory: 2.86 GB
Total physical memory increase: 1.27 GB
```
