### PR TITLE
test: supports two input bits

### DIFF
--- a/src/io/obf.rs
+++ b/src/io/obf.rs
@@ -36,7 +36,6 @@ where
     let dim = obf_params.params.ring_dimension() as usize;
     // let log_q = obf_params.params.modulus_bits();
     let log_base_q = obf_params.params.modulus_digits();
-    debug_assert_eq!(public_circuit.num_input(), (2 * log_base_q) + obf_params.input_size);
     let d = obf_params.d;
     let hash_key = rng.random::<[u8; 32]>();
     sampler_hash.set_key(hash_key);
@@ -46,6 +45,7 @@ where
     log_mem("Sampled public data");
 
     let packed_input_size = public_data.packed_input_size;
+    debug_assert_eq!(public_circuit.num_input(), (2 * log_base_q) + (packed_input_size - 1));
     #[cfg(feature = "test")]
     let reveal_plaintexts = [vec![true; packed_input_size - 1], vec![true; 1]].concat();
     #[cfg(not(feature = "test"))]

--- a/tests/test_io_dummy_param.rs
+++ b/tests/test_io_dummy_param.rs
@@ -50,7 +50,7 @@ mod test {
         let obf_params = ObfuscationParams {
             params: params.clone(),
             switched_modulus,
-            input_size: 1,
+            input_size: 2,
             public_circuit: public_circuit.clone(),
             d: 3,
             encoding_sigma: 0.0,
@@ -75,7 +75,7 @@ mod test {
         info!("Time to obfuscate: {:?}", obfuscation_time);
 
         let bool_in = rng.random::<bool>();
-        let input = [bool_in];
+        let input = [bool_in, false];
         let sampler_hash = DCRTPolyHashSampler::<Keccak256>::new([0; 32]);
         let output =
             obfuscation.eval::<_, DCRTPolyTrapdoorSampler>(obf_params, sampler_hash, &input);


### PR DESCRIPTION
To satisfy the AND gate circuit, the second input bit is hardcoded to false such that the evaluator polynomial is equal to a const monomial for the first input bit. 