### PR TITLE
feat: larger width

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This disables helper logic and fields used only for testing, which are not requi
 
 - **Dummy parameters**  
 ```bash
-cargo test -r --test test_io_dummy_param --no-default-features -- --ignored --nocapture
+cargo test -r --test test_io_dummy_param --no-default-features -- --nocapture
 ```
 
 - **Real parameters** (tests are ignored by default)  

--- a/src/bgg/circuit/utils.rs
+++ b/src/bgg/circuit/utils.rs
@@ -4,8 +4,8 @@ use super::PolyCircuit;
 
 /// Build a circuit that is a composition of two sub-circuits:
 /// 1. A public circuit that it is assumed to return one or more ciphertexts where each ciphertext
-///    is base decomposed -> BaseDecompose(ct_0), BaseDecompose(ct_1), ... where BaseDecompose(ct_k) = [a_base_0, b_base_0,
-///    a_base_1, b_base_1, ...]
+///    is base decomposed -> BaseDecompose(ct_0), BaseDecompose(ct_1), ... where BaseDecompose(ct_k)
+///    = [a_base_0, b_base_0, a_base_1, b_base_1, ...]
 /// 2. An FHE decryption circuit that takes each ciphertext and the RLWE secret key -t_bar as inputs
 ///    and returns the base decomposed plaintext for each cipheretxt
 pub fn build_composite_circuit_from_public_and_fhe_dec<E: Evaluable>(

--- a/src/bgg/circuit/utils.rs
+++ b/src/bgg/circuit/utils.rs
@@ -4,10 +4,10 @@ use super::PolyCircuit;
 
 /// Build a circuit that is a composition of two sub-circuits:
 /// 1. A public circuit that it is assumed to return one or more ciphertexts where each ciphertext
-///    is base decomposed -> BITS(ct_0), BITS(ct_1), ... where BITS(ct_k) = [a_base_0, b_base_0,
+///    is base decomposed -> BaseDecompose(ct_0), BaseDecompose(ct_1), ... where BaseDecompose(ct_k) = [a_base_0, b_base_0,
 ///    a_base_1, b_base_1, ...]
 /// 2. An FHE decryption circuit that takes each ciphertext and the RLWE secret key -t_bar as inputs
-///    and returns the bit decomposed plaintext for each cipheretxt
+///    and returns the base decomposed plaintext for each cipheretxt
 pub fn build_composite_circuit_from_public_and_fhe_dec<E: Evaluable>(
     public_circuit: PolyCircuit,
     log_base_q: usize,

--- a/src/io/eval.rs
+++ b/src/io/eval.rs
@@ -43,7 +43,7 @@ where
         #[cfg(not(feature = "test"))]
         let reveal_plaintexts = [vec![true; packed_input_size - 1], vec![false; 1]].concat();
         let level_width_exp = obf_params.level_width_exp;
-        let level_width = 2u32.pow(level_width_exp as u32) as usize;
+        let level_width = (1u64 << obf_params.level_width_exp) as usize;
         assert!(inputs.len() % level_width_exp == 0);
         let depth = obf_params.input_size / level_width_exp;
         let pubkeys = (0..depth + 1)
@@ -93,7 +93,7 @@ where
                 chunk.iter().enumerate().fold(0u64, |acc, (i, &bit)| acc + ((bit as u64) << i))
             })
             .collect();
-        assert_eq!(nums.len(), depth);
+        debug_assert_eq!(nums.len(), depth);
         for (level, num) in nums.iter().enumerate() {
             let m = &self.m_preimages[level][*num as usize];
             let q = ps[level].clone() * m;
@@ -124,13 +124,11 @@ where
                     let mut coeffs = encode.plaintext.as_ref().unwrap().coeffs().clone();
                     let num_bits: Vec<bool> =
                         (0..level_width_exp).map(|i| (num >> i) & 1 == 1).collect();
-                    assert_eq!(num_bits.len(), level_width_exp);
+                    debug_assert_eq!(num_bits.len(), level_width_exp);
                     for (i, coeff_idx) in inserted_coeff_indices.iter().enumerate() {
                         let bit = num_bits[i];
                         if bit {
                             coeffs[*coeff_idx] = <M::P as Poly>::Elem::one(&params.modulus());
-                        } else {
-                            coeffs[*coeff_idx] = <M::P as Poly>::Elem::zero(&params.modulus());
                         }
                     }
                     Some(M::P::from_coeffs(params.as_ref(), &coeffs))

--- a/src/io/eval.rs
+++ b/src/io/eval.rs
@@ -169,7 +169,7 @@ where
                     let inserted_poly_gadget = {
                         let mut polys = vec![];
                         polys.push(one.clone());
-                        let mut coeffs: Vec<<<M as PolyMatrix>::P as Poly>::Elem> = vec![];
+                        let mut coeffs = vec![];
                         for bit in inputs[0..(level_width_exp * (level + 1))].iter() {
                             if *bit {
                                 coeffs.push(<M::P as Poly>::Elem::one(&params.modulus()));

--- a/src/io/eval.rs
+++ b/src/io/eval.rs
@@ -42,12 +42,15 @@ where
         let reveal_plaintexts = [vec![true; packed_input_size - 1], vec![true; 1]].concat();
         #[cfg(not(feature = "test"))]
         let reveal_plaintexts = [vec![true; packed_input_size - 1], vec![false; 1]].concat();
-        let pubkeys = (0..obf_params.input_size + 1)
-            .map(|idx| {
+        let level_width_exp = obf_params.level_width_exp;
+        let level_width = 2u32.pow(level_width_exp as u32) as usize;
+        let depth = obf_params.input_size / level_width_exp;
+        let pubkeys = (0..depth + 1)
+            .map(|id| {
                 sample_public_key_by_id(
                     &bgg_pubkey_sampler,
                     &obf_params.params,
-                    idx,
+                    id,
                     &reveal_plaintexts,
                 )
             })
@@ -61,7 +64,7 @@ where
         {
             let expected_p_init = {
                 let s_connect = self.s_init.concat_columns(&[&self.s_init]);
-                s_connect * &self.bs[0][2]
+                s_connect * &self.bs[0][level_width]
             };
             assert_eq!(self.p_init, expected_p_init);
 

--- a/src/io/eval.rs
+++ b/src/io/eval.rs
@@ -44,7 +44,7 @@ where
         let reveal_plaintexts = [vec![true; packed_input_size - 1], vec![false; 1]].concat();
         let pubkeys = (0..obf_params.input_size + 1)
             .map(|idx| {
-                sample_public_key_by_idx(
+                sample_public_key_by_id(
                     &bgg_pubkey_sampler,
                     &obf_params.params,
                     idx,
@@ -184,7 +184,7 @@ where
         let a_decomposed = public_data.a_rlwe_bar.entry(0, 0).decompose_base(params.as_ref());
         let b_decomposed = &self.ct_b.entry(0, 0).decompose_base(params.as_ref());
         log_mem("a,b decomposed");
-        let final_circuit = build_final_bits_circuit::<M::P, BggEncoding<M>>(
+        let final_circuit = build_final_digits_circuit::<M::P, BggEncoding<M>>(
             &a_decomposed,
             b_decomposed,
             obf_params.public_circuit.clone(),

--- a/src/io/eval.rs
+++ b/src/io/eval.rs
@@ -90,11 +90,7 @@ where
         let nums: Vec<u64> = inputs
             .chunks(level_width_exp)
             .map(|chunk| {
-                chunk
-                    .iter()
-                    .rev()
-                    .enumerate()
-                    .fold(0u64, |acc, (i, &bit)| acc + ((bit as u64) << i))
+                chunk.iter().enumerate().fold(0u64, |acc, (i, &bit)| acc + ((bit as u64) << i))
             })
             .collect();
         assert_eq!(nums.len(), depth);
@@ -164,7 +160,7 @@ where
                 let b_next_bit = self.bs[level + 1][*num as usize].clone();
                 let expected_q = cur_s.concat_columns(&[&new_s]) * &b_next_bit;
                 assert_eq!(q, expected_q);
-                let expected_p = new_s.concat_columns(&[&new_s]) * &self.bs[level + 1][2];
+                let expected_p = new_s.concat_columns(&[&new_s]) * &self.bs[level + 1][level_width];
                 assert_eq!(p, expected_p);
                 let expcted_new_encode = {
                     let dim = params.ring_dimension() as usize;

--- a/src/io/eval.rs
+++ b/src/io/eval.rs
@@ -94,10 +94,10 @@ where
             let v = q.clone() * k;
             log_mem(format!("v at {} computed", idx));
             let new_encode_vec = {
-                let t = if *input { &public_data.rgs[1] } else { &public_data.rgs[0] };
+                let rg = if *input { &public_data.rgs[1] } else { &public_data.rgs[0] };
                 let encode_vec = encodings[idx][0].concat_vector(&encodings[idx][1..]);
                 let packed_input_size = obf_params.input_size.div_ceil(dim) + 1;
-                encode_vec.mul_tensor_identity_decompose(t, packed_input_size + 1) + v
+                encode_vec.mul_tensor_identity_decompose(rg, packed_input_size + 1) + v
             };
             log_mem(format!("new_encode_vec at {} computed", idx));
             let mut new_encodings = vec![];
@@ -134,13 +134,14 @@ where
             {
                 let mut cur_s = self.s_init.clone();
                 for bit in inputs[0..idx].iter() {
-                    let r = if *bit { public_data.r_1.clone() } else { public_data.r_0.clone() };
+                    let r =
+                        if *bit { public_data.rs[1].clone() } else { public_data.rs[0].clone() };
                     cur_s = cur_s * r;
                 }
                 let new_s = if *input {
-                    cur_s.clone() * &public_data.r_1
+                    cur_s.clone() * &public_data.rs[1]
                 } else {
-                    cur_s.clone() * &public_data.r_0
+                    cur_s.clone() * &public_data.rs[0]
                 };
                 let b_next_bit =
                     if *input { self.bs[idx + 1][1].clone() } else { self.bs[idx + 1][0].clone() };
@@ -216,7 +217,7 @@ where
         {
             let mut last_s = self.s_init.clone();
             for bit in inputs.iter() {
-                let r = if *bit { public_data.r_1.clone() } else { public_data.r_0.clone() };
+                let r = if *bit { public_data.rs[1].clone() } else { public_data.rs[0].clone() };
                 last_s = last_s * r;
             }
             {

--- a/src/io/obf.rs
+++ b/src/io/obf.rs
@@ -120,9 +120,12 @@ where
     log_mem("Computed p_init");
 
     let identity_d_plus_1 = M::identity(params.as_ref(), d + 1, None);
-    let u_0 = identity_d_plus_1.concat_diag(&[&public_data.r_0]);
-    let u_1 = identity_d_plus_1.concat_diag(&[&public_data.r_1]);
-    let u_bits = [u_0, u_1];
+    let level_width = 2u64.pow(obf_params.level_width as u32);
+    let mut u_bits = Vec::with_capacity((level_width + 1) as usize);
+    for i in 0..level_width {
+        let u_i = identity_d_plus_1.concat_diag(&[&public_data.rs[i as usize]]);
+        u_bits.push(u_i);
+    }
     let u_star = {
         let zeros = M::zero(params.as_ref(), d + 1, 2 * (d + 1));
         let identities = identity_d_plus_1.concat_columns(&[&identity_d_plus_1]);

--- a/src/io/obf.rs
+++ b/src/io/obf.rs
@@ -35,7 +35,6 @@ where
     let public_circuit = &obf_params.public_circuit;
     let dim = obf_params.params.ring_dimension() as usize;
     let log_base_q = obf_params.params.modulus_digits();
-    debug_assert_eq!(public_circuit.num_input(), (2 * log_base_q) + obf_params.input_size);
     let d = obf_params.d;
     let hash_key = rng.random::<[u8; 32]>();
     sampler_hash.set_key(hash_key);
@@ -43,8 +42,8 @@ where
     let bgg_pubkey_sampler = BGGPublicKeySampler::new(Arc::new(sampler_hash), d);
     let public_data = PublicSampledData::sample(&obf_params, &bgg_pubkey_sampler);
     log_mem("Sampled public data");
-
     let packed_input_size = public_data.packed_input_size;
+    debug_assert_eq!(public_circuit.num_input(), (2 * log_base_q) + (packed_input_size - 1));
     #[cfg(feature = "test")]
     let reveal_plaintexts = [vec![true; packed_input_size - 1], vec![true; 1]].concat();
     #[cfg(not(feature = "test"))]

--- a/src/io/obf.rs
+++ b/src/io/obf.rs
@@ -34,7 +34,6 @@ where
 {
     let public_circuit = &obf_params.public_circuit;
     let dim = obf_params.params.ring_dimension() as usize;
-    // let log_q = obf_params.params.modulus_bits();
     let log_base_q = obf_params.params.modulus_digits();
     debug_assert_eq!(public_circuit.num_input(), (2 * log_base_q) + obf_params.input_size);
     let d = obf_params.d;
@@ -120,10 +119,12 @@ where
     log_mem("Computed p_init");
 
     let identity_d_plus_1 = M::identity(params.as_ref(), d + 1, None);
-    let level_width = 2u64.pow(obf_params.level_width as u32);
-    let mut u_bits = Vec::with_capacity((level_width + 1) as usize);
+    assert_eq!(obf_params.input_size % obf_params.level_width_exp, 0);
+    assert_eq!(dim % obf_params.level_width_exp, 0);
+    let level_width = 2u64.pow(obf_params.level_width_exp as u32) as usize;
+    let mut u_bits = Vec::with_capacity(level_width + 1);
     for i in 0..level_width {
-        let u_i = identity_d_plus_1.concat_diag(&[&public_data.rs[i as usize]]);
+        let u_i = identity_d_plus_1.concat_diag(&[&public_data.rs[i]]);
         u_bits.push(u_i);
     }
     let u_star = {
@@ -134,9 +135,9 @@ where
     log_mem("Computed u_0, u_1, u_star");
 
     let (mut m_preimages, mut n_preimages, mut k_preimages) = (
-        vec![Vec::with_capacity(2); obf_params.input_size],
-        vec![Vec::with_capacity(2); obf_params.input_size],
-        vec![Vec::with_capacity(2); obf_params.input_size],
+        vec![Vec::with_capacity(level_width); obf_params.input_size],
+        vec![Vec::with_capacity(level_width); obf_params.input_size],
+        vec![Vec::with_capacity(level_width); obf_params.input_size],
     );
 
     #[cfg(feature = "test")]

--- a/src/io/params.rs
+++ b/src/io/params.rs
@@ -8,7 +8,7 @@ pub struct ObfuscationParams<M: PolyMatrix> {
     pub params: <<M as PolyMatrix>::P as Poly>::Params,
     pub switched_modulus: <<<M as PolyMatrix>::P as Poly>::Params as PolyParams>::Modulus,
     pub input_size: usize,
-    pub level_width_exp: usize, // number of bits to be inserted at each level
+    pub level_width: usize, // number of bits to be inserted at each level
     pub public_circuit: PolyCircuit,
     pub d: usize,
     pub encoding_sigma: f64,

--- a/src/io/params.rs
+++ b/src/io/params.rs
@@ -8,7 +8,7 @@ pub struct ObfuscationParams<M: PolyMatrix> {
     pub params: <<M as PolyMatrix>::P as Poly>::Params,
     pub switched_modulus: <<<M as PolyMatrix>::P as Poly>::Params as PolyParams>::Modulus,
     pub input_size: usize,
-    pub level_width: usize,
+    pub level_width_exp: usize, // number of bits inserted at each level
     pub public_circuit: PolyCircuit,
     pub d: usize,
     pub encoding_sigma: f64,

--- a/src/io/params.rs
+++ b/src/io/params.rs
@@ -8,7 +8,7 @@ pub struct ObfuscationParams<M: PolyMatrix> {
     pub params: <<M as PolyMatrix>::P as Poly>::Params,
     pub switched_modulus: <<<M as PolyMatrix>::P as Poly>::Params as PolyParams>::Modulus,
     pub input_size: usize,
-    pub level_width_exp: usize, // number of bits inserted at each level
+    pub level_width_exp: usize, // number of bits to be inserted at each level
     pub public_circuit: PolyCircuit,
     pub d: usize,
     pub encoding_sigma: f64,

--- a/src/io/params.rs
+++ b/src/io/params.rs
@@ -8,6 +8,7 @@ pub struct ObfuscationParams<M: PolyMatrix> {
     pub params: <<M as PolyMatrix>::P as Poly>::Params,
     pub switched_modulus: <<<M as PolyMatrix>::P as Poly>::Params as PolyParams>::Modulus,
     pub input_size: usize,
+    pub level_width: usize,
     pub public_circuit: PolyCircuit,
     pub d: usize,
     pub encoding_sigma: f64,

--- a/src/io/utils.rs
+++ b/src/io/utils.rs
@@ -49,12 +49,12 @@ impl<S: PolyHashSampler<[u8; 32]>> PublicSampledData<S> {
         let hash_sampler = &bgg_pubkey_sampler.sampler;
         let params = &obf_params.params;
         let d = obf_params.d;
-        let level_width = (1u64 << obf_params.level_width_exp) as usize;
-        let mut rs = Vec::with_capacity(level_width);
-        let mut rgs = Vec::with_capacity(level_width);
+        let level_size = (1u64 << obf_params.level_width) as usize;
+        let mut rs = Vec::with_capacity(level_size);
+        let mut rgs = Vec::with_capacity(level_size);
         let one = S::M::identity(params, 1, None);
         let gadget_d_plus_1 = S::M::gadget_matrix(params, d + 1);
-        for i in 0..level_width {
+        for i in 0..level_size {
             let tag = format!("R_{}", i).into_bytes();
             let r_i_bar = hash_sampler.sample_hash(params, &tag, d, d, DistType::BitDist);
             let r_i = r_i_bar.concat_diag(&[&one]);

--- a/src/io/utils.rs
+++ b/src/io/utils.rs
@@ -11,7 +11,6 @@ use std::marker::PhantomData;
 use super::params::ObfuscationParams;
 
 const TAG_A_RLWE_BAR: &[u8] = b"A_RLWE_BAR";
-const _TAG_BGG_PUBKEY_FHEKEY_PREFIX: &[u8] = b"BGG_PUBKEY_FHEKY:";
 const TAG_A_PRF: &[u8] = b"A_PRF:";
 pub const TAG_BGG_PUBKEY_INPUT_PREFIX: &[u8] = b"BGG_PUBKEY_INPUT:";
 
@@ -50,15 +49,15 @@ impl<S: PolyHashSampler<[u8; 32]>> PublicSampledData<S> {
         let hash_sampler = &bgg_pubkey_sampler.sampler;
         let params = &obf_params.params;
         let d = obf_params.d;
-        let level_width = 2u64.pow(obf_params.level_width_exp as u32);
-        let mut rs = Vec::with_capacity(level_width as usize);
-        let mut rgs = Vec::with_capacity(level_width as usize);
+        let level_width = (1u64 << obf_params.level_width_exp) as usize;
+        let mut rs = Vec::with_capacity(level_width);
+        let mut rgs = Vec::with_capacity(level_width);
         let one = S::M::identity(params, 1, None);
         let gadget_d_plus_1 = S::M::gadget_matrix(params, d + 1);
         for i in 0..level_width {
             let tag = format!("R_{}", i).into_bytes();
-            let r_bar_i = hash_sampler.sample_hash(params, &tag, d, d, DistType::BitDist);
-            let r_i = r_bar_i.concat_diag(&[&one]);
+            let r_i_bar = hash_sampler.sample_hash(params, &tag, d, d, DistType::BitDist);
+            let r_i = r_i_bar.concat_diag(&[&one]);
             let rg = r_i.clone() * &gadget_d_plus_1;
             rs.push(r_i);
             rgs.push(rg);

--- a/src/io/utils.rs
+++ b/src/io/utils.rs
@@ -50,7 +50,7 @@ impl<S: PolyHashSampler<[u8; 32]>> PublicSampledData<S> {
         let hash_sampler = &bgg_pubkey_sampler.sampler;
         let params = &obf_params.params;
         let d = obf_params.d;
-        let level_width = 2u64.pow(obf_params.level_width as u32);
+        let level_width = 2u64.pow(obf_params.level_width_exp as u32);
         let mut rs = Vec::with_capacity(level_width as usize);
         let mut rgs = Vec::with_capacity(level_width as usize);
         let one = S::M::identity(params, 1, None);

--- a/tests/test_bgg_pubkey.rs
+++ b/tests/test_bgg_pubkey.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use diamond_io::{
     bgg::{circuit::PolyCircuit, sampler::BGGPublicKeySampler, BggPublicKey, DigitsToInt},
-    io::utils::build_final_bits_circuit,
+    io::utils::build_final_digits_circuit,
     poly::{
         dcrt::{
             DCRTPoly, DCRTPolyHashSampler, DCRTPolyMatrix, DCRTPolyParams, DCRTPolyUniformSampler,
@@ -25,8 +25,8 @@ fn test_build_final_step_circuit() {
     let log_base_q = params.modulus_digits();
     let mut public_circuit = PolyCircuit::new();
 
-    // inputs: BITS(ct), eval_input
-    // outputs: BITS(ct) AND eval_input
+    // inputs: BaseDecompose(ct), eval_input
+    // outputs: BaseDecompose(ct) AND eval_input
     {
         let inputs = public_circuit.input((2 * log_base_q) + 1);
         let mut outputs = vec![];
@@ -65,9 +65,9 @@ fn test_build_final_step_circuit() {
 
     let a_decomposed = a_rlwe_bar.entry(0, 0).decompose_base(&params);
     let b_decomposed = b.entry(0, 0).decompose_base(&params);
-    log_mem("Decomposed RLWE ciphertext into {bits(a), bits(b)}");
+    log_mem("Decomposed RLWE ciphertext into {BaseDecompose(a), BaseDecompose(b)}");
 
-    let final_circuit = build_final_bits_circuit::<DCRTPoly, BggPublicKey<DCRTPolyMatrix>>(
+    let final_circuit = build_final_digits_circuit::<DCRTPoly, BggPublicKey<DCRTPolyMatrix>>(
         &a_decomposed,
         &b_decomposed,
         public_circuit.clone(),

--- a/tests/test_io_dummy_param.rs
+++ b/tests/test_io_dummy_param.rs
@@ -51,7 +51,7 @@ mod test {
             params: params.clone(),
             switched_modulus,
             input_size: 4,
-            level_width_exp: 4,
+            level_width_exp: 2,
             public_circuit: public_circuit.clone(),
             d: 3,
             encoding_sigma: 0.0,

--- a/tests/test_io_dummy_param.rs
+++ b/tests/test_io_dummy_param.rs
@@ -50,8 +50,8 @@ mod test {
         let obf_params = ObfuscationParams {
             params: params.clone(),
             switched_modulus,
-            input_size: 2,
-            level_width_exp: 1,
+            input_size: 4,
+            level_width_exp: 4,
             public_circuit: public_circuit.clone(),
             d: 3,
             encoding_sigma: 0.0,
@@ -76,7 +76,7 @@ mod test {
         info!("Time to obfuscate: {:?}", obfuscation_time);
 
         let bool_in = rng.random::<bool>();
-        let input = [bool_in, false];
+        let input = [bool_in, false, false, false];
         let sampler_hash = DCRTPolyHashSampler::<Keccak256>::new([0; 32]);
         let output =
             obfuscation.eval::<_, DCRTPolyTrapdoorSampler>(obf_params, sampler_hash, &input);

--- a/tests/test_io_dummy_param.rs
+++ b/tests/test_io_dummy_param.rs
@@ -51,7 +51,7 @@ mod test {
             params: params.clone(),
             switched_modulus,
             input_size: 4,
-            level_width_exp: 1,
+            level_width: 1,
             public_circuit: public_circuit.clone(),
             d: 3,
             encoding_sigma: 0.0,

--- a/tests/test_io_dummy_param.rs
+++ b/tests/test_io_dummy_param.rs
@@ -51,6 +51,7 @@ mod test {
             params: params.clone(),
             switched_modulus,
             input_size: 1,
+            level_width: 1,
             public_circuit: public_circuit.clone(),
             d: 3,
             encoding_sigma: 0.0,

--- a/tests/test_io_dummy_param.rs
+++ b/tests/test_io_dummy_param.rs
@@ -30,8 +30,8 @@ mod test {
         let switched_modulus = Arc::new(BigUint::from(1u32));
         let mut public_circuit = PolyCircuit::new();
 
-        // inputs: BITS(ct), eval_input
-        // outputs: BITS(ct) AND eval_input, BITS(ct) AND eval_input
+        // inputs: BaseDecompose(ct), eval_input
+        // outputs: BaseDecompose(ct) AND eval_input, BaseDecompose(ct) AND eval_input
         {
             let inputs = public_circuit.input((2 * log_base_q) + 1);
             let mut outputs = vec![];

--- a/tests/test_io_dummy_param.rs
+++ b/tests/test_io_dummy_param.rs
@@ -50,7 +50,7 @@ mod test {
         let obf_params = ObfuscationParams {
             params: params.clone(),
             switched_modulus,
-            input_size: 1,
+            input_size: 2,
             level_width_exp: 1,
             public_circuit: public_circuit.clone(),
             d: 3,
@@ -76,7 +76,7 @@ mod test {
         info!("Time to obfuscate: {:?}", obfuscation_time);
 
         let bool_in = rng.random::<bool>();
-        let input = [bool_in];
+        let input = [bool_in, false];
         let sampler_hash = DCRTPolyHashSampler::<Keccak256>::new([0; 32]);
         let output =
             obfuscation.eval::<_, DCRTPolyTrapdoorSampler>(obf_params, sampler_hash, &input);

--- a/tests/test_io_dummy_param.rs
+++ b/tests/test_io_dummy_param.rs
@@ -51,7 +51,7 @@ mod test {
             params: params.clone(),
             switched_modulus,
             input_size: 1,
-            level_width: 1,
+            level_width_exp: 1,
             public_circuit: public_circuit.clone(),
             d: 3,
             encoding_sigma: 0.0,

--- a/tests/test_io_dummy_param_width.rs
+++ b/tests/test_io_dummy_param_width.rs
@@ -22,7 +22,7 @@ mod test {
     const SIGMA: f64 = 4.578;
 
     #[test]
-    fn test_io_just_mul_enc_and_and_bit() {
+    fn test_io_just_mul_enc_and_and_bit_large_width() {
         init_tracing();
         let start_time = std::time::Instant::now();
         let params = DCRTPolyParams::new(4, 2, 17, 10);
@@ -51,7 +51,7 @@ mod test {
             params: params.clone(),
             switched_modulus,
             input_size: 4,
-            level_width_exp: 1,
+            level_width_exp: 2,
             public_circuit: public_circuit.clone(),
             d: 3,
             encoding_sigma: 0.0,

--- a/tests/test_io_dummy_param_width.rs
+++ b/tests/test_io_dummy_param_width.rs
@@ -22,7 +22,7 @@ mod test {
     const SIGMA: f64 = 4.578;
 
     #[test]
-    fn test_io_just_mul_enc_and_and_bit_large_width() {
+    fn test_io_just_mul_enc_and_and_bit_width() {
         init_tracing();
         let start_time = std::time::Instant::now();
         let params = DCRTPolyParams::new(4, 2, 17, 10);
@@ -51,7 +51,7 @@ mod test {
             params: params.clone(),
             switched_modulus,
             input_size: 4,
-            level_width_exp: 2,
+            level_width: 2,
             public_circuit: public_circuit.clone(),
             d: 3,
             encoding_sigma: 0.0,

--- a/tests/test_io_middle_param.rs
+++ b/tests/test_io_middle_param.rs
@@ -37,8 +37,8 @@ mod test {
         );
         let mut public_circuit = PolyCircuit::new();
 
-        // inputs: BITS(ct), eval_input
-        // outputs: BITS(ct) AND eval_input
+        // inputs: BaseDecompose(ct), eval_input
+        // outputs: BaseDecompose(ct) AND eval_input
         {
             let inputs = public_circuit.input((2 * log_base_q) + 1);
             let mut outputs = vec![];

--- a/tests/test_io_middle_param.rs
+++ b/tests/test_io_middle_param.rs
@@ -54,7 +54,7 @@ mod test {
             params: params.clone(),
             switched_modulus,
             input_size: 1,
-            level_width_exp: 1,
+            level_width: 1,
             public_circuit: public_circuit.clone(),
             d: 1,
             encoding_sigma: 15.82764,

--- a/tests/test_io_middle_param.rs
+++ b/tests/test_io_middle_param.rs
@@ -54,7 +54,7 @@ mod test {
             params: params.clone(),
             switched_modulus,
             input_size: 1,
-            level_width: 1,
+            level_width_exp: 1,
             public_circuit: public_circuit.clone(),
             d: 1,
             encoding_sigma: 15.82764,

--- a/tests/test_io_middle_param.rs
+++ b/tests/test_io_middle_param.rs
@@ -54,6 +54,7 @@ mod test {
             params: params.clone(),
             switched_modulus,
             input_size: 1,
+            level_width: 1,
             public_circuit: public_circuit.clone(),
             d: 1,
             encoding_sigma: 15.82764,

--- a/tests/test_io_real_param.rs
+++ b/tests/test_io_real_param.rs
@@ -32,8 +32,8 @@ mod test {
         let switched_modulus = Arc::new(BigUint::from_str_radix("242833611528216133864932738352844082358996736827870043467279656893386864455514587136", 10).unwrap());
         let mut public_circuit = PolyCircuit::new();
 
-        // inputs: BITS(ct), eval_input
-        // outputs: BITS(ct) AND eval_input
+        // inputs: BaseDecompose(ct), eval_input
+        // outputs: BaseDecompose(ct) AND eval_input
         {
             let inputs = public_circuit.input((2 * log_base_q) + 1);
             let mut outputs = vec![];

--- a/tests/test_io_real_param.rs
+++ b/tests/test_io_real_param.rs
@@ -49,7 +49,7 @@ mod test {
             params: params.clone(),
             switched_modulus,
             input_size: 1,
-            level_width: 1,
+            level_width_exp: 1,
             public_circuit: public_circuit.clone(),
             d: 1,
             encoding_sigma: 12.05698,

--- a/tests/test_io_real_param.rs
+++ b/tests/test_io_real_param.rs
@@ -49,6 +49,7 @@ mod test {
             params: params.clone(),
             switched_modulus,
             input_size: 1,
+            level_width: 1,
             public_circuit: public_circuit.clone(),
             d: 1,
             encoding_sigma: 12.05698,

--- a/tests/test_io_real_param.rs
+++ b/tests/test_io_real_param.rs
@@ -49,7 +49,7 @@ mod test {
             params: params.clone(),
             switched_modulus,
             input_size: 1,
-            level_width_exp: 1,
+            level_width: 1,
             public_circuit: public_circuit.clone(),
             d: 1,
             encoding_sigma: 12.05698,


### PR DESCRIPTION
Obfuscation now supports `level_width` which indicates the number of bits to be inserted at each diamond level

Right now we only support 1 bit insertion per step

<img width="1311" alt="Screenshot 2025-04-15 at 09 00 12" src="https://github.com/user-attachments/assets/609e14f4-b419-4123-811b-e3fd48f65172" />

While this is the new scenario when setting `level_width = 2` 

![IMG_0759](https://github.com/user-attachments/assets/c086ff55-29d8-412e-b411-d803b0ab0517)

The advantage is that the noise growth of the p vector after 1 diamond step is the same in the two scenarios. Note the number of preimages to be generated at each diamond step is equal to 2^level_width_exp, namely every possible bit combination that can be inserted

## Benches 

`input_size = 4`
`level_width = 1`

```
cargo test -r --test test_io_dummy_param --no-default-features -- --nocapture
```

```
Time to obfuscate: 19.711899334s
Time for evaluation: 713.147916ms
Total time: 20.42504725s
```


`input_size = 4`
`level_width = 2`

```
cargo test -r --test test_io_dummy_param_width --no-default-features -- --nocapture
```

```
Time to obfuscate: 19.80427s
Time for evaluation: 507.876375ms
Total time: 20.312146375s
```