### PR TITLE
chore: clean obfuscation, evaluation interface

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,7 @@
+[workspace]
+resolver = "2"
+members = ["cli", "."]
+
 [package]
 name = "diamond-io"
 version = "0.1.0"
@@ -59,6 +63,7 @@ codegen-units = 16
 inherits = "release"
 debug = "full"
 strip = "none"
+
 
 [[bench]]
 name = "dcrtpoly"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "dio"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+clap = { version = "4.5.36", features = ["derive"] }
+diamond-io = { path = "../" }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,0 +1,17 @@
+use std::path::PathBuf;
+
+use clap::Parser;
+
+#[derive(Parser)]
+#[command(version, about, long_about = None)]
+struct Cli {
+    /// Sets a custom config file
+    #[arg(short, long, value_name = "FILE")]
+    config: PathBuf,
+}
+
+fn main() {
+    let cli = Cli::parse();
+
+    todo!()
+}

--- a/src/bgg/circuit/mod.rs
+++ b/src/bgg/circuit/mod.rs
@@ -400,7 +400,7 @@ mod tests {
                 DCRTPolyMatrix, FinRingElem,
             },
             enc::rlwe_encrypt,
-            sampler::DistType,
+            sampler::{DistType, PolyUniformSampler},
             Poly, PolyMatrix, PolyParams,
         },
         utils::{create_bit_random_poly, create_random_poly},

--- a/src/bgg/digits_to_int.rs
+++ b/src/bgg/digits_to_int.rs
@@ -73,7 +73,6 @@ mod tests {
         utils::{create_bit_random_poly, create_random_poly},
     };
     use keccak_asm::Keccak256;
-    use std::sync::Arc;
 
     #[test]
     fn test_dcrtpoly_digits_to_int_random() {
@@ -160,7 +159,7 @@ mod tests {
         let d = 3;
         let bgg_pubkey_sampler =
             BGGPublicKeySampler::<_, DCRTPolyHashSampler<Keccak256>>::new(key, d);
-        let uniform_sampler = Arc::new(DCRTPolyUniformSampler::new());
+        let uniform_sampler = DCRTPolyUniformSampler::new();
 
         // Generate random tag for sampling
         let tag: u64 = rand::random();
@@ -198,7 +197,7 @@ mod tests {
         let d = 3;
         let bgg_pubkey_sampler =
             BGGPublicKeySampler::<_, DCRTPolyHashSampler<Keccak256>>::new(key, d);
-        let uniform_sampler = Arc::new(DCRTPolyUniformSampler::new());
+        let uniform_sampler = DCRTPolyUniformSampler::new();
 
         // Generate random tag for sampling
         let tag: u64 = rand::random();

--- a/src/bgg/digits_to_int.rs
+++ b/src/bgg/digits_to_int.rs
@@ -67,6 +67,7 @@ mod tests {
                 poly::DCRTPoly,
                 sampler::{hash::DCRTPolyHashSampler, uniform::DCRTPolyUniformSampler},
             },
+            sampler::PolyUniformSampler,
             PolyElem,
         },
         utils::{create_bit_random_poly, create_random_poly},
@@ -115,9 +116,8 @@ mod tests {
 
         // Create a hash sampler and BGGPublicKeySampler
         let key: [u8; 32] = rand::random();
-        let hash_sampler = Arc::new(DCRTPolyHashSampler::<Keccak256>::new(key));
         let d = 3;
-        let bgg_sampler = BGGPublicKeySampler::new(hash_sampler, d);
+        let bgg_sampler = BGGPublicKeySampler::<_, DCRTPolyHashSampler<Keccak256>>::new(key, d);
 
         // Generate random tag for sampling
         let tag: u64 = rand::random();
@@ -157,9 +157,9 @@ mod tests {
 
         // Create samplers
         let key: [u8; 32] = rand::random();
-        let hash_sampler = Arc::new(DCRTPolyHashSampler::<Keccak256>::new(key));
         let d = 3;
-        let bgg_pubkey_sampler = BGGPublicKeySampler::new(hash_sampler, d);
+        let bgg_pubkey_sampler =
+            BGGPublicKeySampler::<_, DCRTPolyHashSampler<Keccak256>>::new(key, d);
         let uniform_sampler = Arc::new(DCRTPolyUniformSampler::new());
 
         // Generate random tag for sampling
@@ -195,9 +195,9 @@ mod tests {
 
         // Create samplers
         let key: [u8; 32] = rand::random();
-        let hash_sampler = Arc::new(DCRTPolyHashSampler::<Keccak256>::new(key));
         let d = 3;
-        let bgg_pubkey_sampler = BGGPublicKeySampler::new(hash_sampler, d);
+        let bgg_pubkey_sampler =
+            BGGPublicKeySampler::<_, DCRTPolyHashSampler<Keccak256>>::new(key, d);
         let uniform_sampler = Arc::new(DCRTPolyUniformSampler::new());
 
         // Generate random tag for sampling

--- a/src/bgg/encoding.rs
+++ b/src/bgg/encoding.rs
@@ -122,9 +122,12 @@ mod tests {
             circuit::PolyCircuit,
             sampler::{BGGEncodingSampler, BGGPublicKeySampler},
         },
-        poly::dcrt::{
-            params::DCRTPolyParams,
-            sampler::{hash::DCRTPolyHashSampler, uniform::DCRTPolyUniformSampler},
+        poly::{
+            dcrt::{
+                params::DCRTPolyParams,
+                sampler::{hash::DCRTPolyHashSampler, uniform::DCRTPolyUniformSampler},
+            },
+            sampler::PolyUniformSampler,
         },
         utils::{create_bit_random_poly, create_random_poly},
     };
@@ -138,9 +141,9 @@ mod tests {
 
         // Create samplers
         let key: [u8; 32] = rand::random();
-        let hash_sampler = Arc::new(DCRTPolyHashSampler::<Keccak256>::new(key));
         let d = 3;
-        let bgg_pubkey_sampler = BGGPublicKeySampler::new(hash_sampler, d);
+        let bgg_pubkey_sampler =
+            BGGPublicKeySampler::<_, DCRTPolyHashSampler<Keccak256>>::new(key, d);
         let uniform_sampler = Arc::new(DCRTPolyUniformSampler::new());
 
         // Generate random tag for sampling
@@ -188,9 +191,9 @@ mod tests {
 
         // Create samplers
         let key: [u8; 32] = rand::random();
-        let hash_sampler = Arc::new(DCRTPolyHashSampler::<Keccak256>::new(key));
         let d = 3;
-        let bgg_pubkey_sampler = BGGPublicKeySampler::new(hash_sampler, d);
+        let bgg_pubkey_sampler =
+            BGGPublicKeySampler::<_, DCRTPolyHashSampler<Keccak256>>::new(key, d);
         let uniform_sampler = Arc::new(DCRTPolyUniformSampler::new());
 
         // Generate random tag for sampling
@@ -238,9 +241,9 @@ mod tests {
 
         // Create samplers
         let key: [u8; 32] = rand::random();
-        let hash_sampler = Arc::new(DCRTPolyHashSampler::<Keccak256>::new(key));
         let d = 3;
-        let bgg_pubkey_sampler = BGGPublicKeySampler::new(hash_sampler, d);
+        let bgg_pubkey_sampler =
+            BGGPublicKeySampler::<_, DCRTPolyHashSampler<Keccak256>>::new(key, d);
         let uniform_sampler = Arc::new(DCRTPolyUniformSampler::new());
 
         // Generate random tag for sampling
@@ -288,9 +291,9 @@ mod tests {
 
         // Create samplers
         let key: [u8; 32] = rand::random();
-        let hash_sampler = Arc::new(DCRTPolyHashSampler::<Keccak256>::new(key));
         let d = 3;
-        let bgg_pubkey_sampler = BGGPublicKeySampler::new(hash_sampler, d);
+        let bgg_pubkey_sampler =
+            BGGPublicKeySampler::<_, DCRTPolyHashSampler<Keccak256>>::new(key, d);
         let uniform_sampler = Arc::new(DCRTPolyUniformSampler::new());
 
         // Generate random tag for sampling
@@ -353,9 +356,9 @@ mod tests {
 
         // Create samplers
         let key: [u8; 32] = rand::random();
-        let hash_sampler = Arc::new(DCRTPolyHashSampler::<Keccak256>::new(key));
         let d = 3;
-        let bgg_pubkey_sampler = BGGPublicKeySampler::new(hash_sampler, d);
+        let bgg_pubkey_sampler =
+            BGGPublicKeySampler::<_, DCRTPolyHashSampler<Keccak256>>::new(key, d);
         let uniform_sampler = Arc::new(DCRTPolyUniformSampler::new());
 
         // Generate random tag for sampling
@@ -439,9 +442,9 @@ mod tests {
 
         // Create samplers
         let key: [u8; 32] = rand::random();
-        let hash_sampler = Arc::new(DCRTPolyHashSampler::<Keccak256>::new(key));
         let d = 3;
-        let bgg_pubkey_sampler = BGGPublicKeySampler::new(hash_sampler, d);
+        let bgg_pubkey_sampler =
+            BGGPublicKeySampler::<_, DCRTPolyHashSampler<Keccak256>>::new(key, d);
         let uniform_sampler = Arc::new(DCRTPolyUniformSampler::new());
 
         // Generate random tag for sampling
@@ -517,9 +520,9 @@ mod tests {
 
         // Create samplers
         let key: [u8; 32] = rand::random();
-        let hash_sampler = Arc::new(DCRTPolyHashSampler::<Keccak256>::new(key));
         let d = 3;
-        let bgg_pubkey_sampler = BGGPublicKeySampler::new(hash_sampler, d);
+        let bgg_pubkey_sampler =
+            BGGPublicKeySampler::<_, DCRTPolyHashSampler<Keccak256>>::new(key, d);
         let uniform_sampler = Arc::new(DCRTPolyUniformSampler::new());
 
         // Generate random tag for sampling

--- a/src/bgg/encoding.rs
+++ b/src/bgg/encoding.rs
@@ -132,7 +132,6 @@ mod tests {
         utils::{create_bit_random_poly, create_random_poly},
     };
     use keccak_asm::Keccak256;
-    use std::sync::Arc;
 
     #[test]
     fn test_encoding_add() {
@@ -144,7 +143,7 @@ mod tests {
         let d = 3;
         let bgg_pubkey_sampler =
             BGGPublicKeySampler::<_, DCRTPolyHashSampler<Keccak256>>::new(key, d);
-        let uniform_sampler = Arc::new(DCRTPolyUniformSampler::new());
+        let uniform_sampler = DCRTPolyUniformSampler::new();
 
         // Generate random tag for sampling
         let tag: u64 = rand::random();
@@ -194,7 +193,7 @@ mod tests {
         let d = 3;
         let bgg_pubkey_sampler =
             BGGPublicKeySampler::<_, DCRTPolyHashSampler<Keccak256>>::new(key, d);
-        let uniform_sampler = Arc::new(DCRTPolyUniformSampler::new());
+        let uniform_sampler = DCRTPolyUniformSampler::new();
 
         // Generate random tag for sampling
         let tag: u64 = rand::random();
@@ -244,7 +243,7 @@ mod tests {
         let d = 3;
         let bgg_pubkey_sampler =
             BGGPublicKeySampler::<_, DCRTPolyHashSampler<Keccak256>>::new(key, d);
-        let uniform_sampler = Arc::new(DCRTPolyUniformSampler::new());
+        let uniform_sampler = DCRTPolyUniformSampler::new();
 
         // Generate random tag for sampling
         let tag: u64 = rand::random();
@@ -294,7 +293,7 @@ mod tests {
         let d = 3;
         let bgg_pubkey_sampler =
             BGGPublicKeySampler::<_, DCRTPolyHashSampler<Keccak256>>::new(key, d);
-        let uniform_sampler = Arc::new(DCRTPolyUniformSampler::new());
+        let uniform_sampler = DCRTPolyUniformSampler::new();
 
         // Generate random tag for sampling
         let tag: u64 = rand::random();
@@ -359,7 +358,7 @@ mod tests {
         let d = 3;
         let bgg_pubkey_sampler =
             BGGPublicKeySampler::<_, DCRTPolyHashSampler<Keccak256>>::new(key, d);
-        let uniform_sampler = Arc::new(DCRTPolyUniformSampler::new());
+        let uniform_sampler = DCRTPolyUniformSampler::new();
 
         // Generate random tag for sampling
         let tag: u64 = rand::random();
@@ -445,7 +444,7 @@ mod tests {
         let d = 3;
         let bgg_pubkey_sampler =
             BGGPublicKeySampler::<_, DCRTPolyHashSampler<Keccak256>>::new(key, d);
-        let uniform_sampler = Arc::new(DCRTPolyUniformSampler::new());
+        let uniform_sampler = DCRTPolyUniformSampler::new();
 
         // Generate random tag for sampling
         let tag: u64 = rand::random();
@@ -523,7 +522,7 @@ mod tests {
         let d = 3;
         let bgg_pubkey_sampler =
             BGGPublicKeySampler::<_, DCRTPolyHashSampler<Keccak256>>::new(key, d);
-        let uniform_sampler = Arc::new(DCRTPolyUniformSampler::new());
+        let uniform_sampler = DCRTPolyUniformSampler::new();
 
         // Generate random tag for sampling
         let tag: u64 = rand::random();

--- a/src/bgg/public_key.rs
+++ b/src/bgg/public_key.rs
@@ -103,7 +103,6 @@ mod tests {
         poly::dcrt::{params::DCRTPolyParams, DCRTPolyHashSampler},
     };
     use keccak_asm::Keccak256;
-    use std::sync::Arc;
 
     #[test]
     fn test_pubkey_add() {
@@ -112,9 +111,8 @@ mod tests {
 
         // Create a hash sampler and BGGPublicKeySampler to be reused
         let key: [u8; 32] = rand::random();
-        let hash_sampler = Arc::new(DCRTPolyHashSampler::<Keccak256>::new(key));
         let d = 3;
-        let bgg_sampler = BGGPublicKeySampler::new(hash_sampler, d);
+        let bgg_sampler = BGGPublicKeySampler::<_, DCRTPolyHashSampler<Keccak256>>::new(key, d);
 
         // Generate random tag for sampling
         let tag: u64 = rand::random();
@@ -152,9 +150,8 @@ mod tests {
 
         // Create a hash sampler and BGGPublicKeySampler to be reused
         let key: [u8; 32] = rand::random();
-        let hash_sampler = Arc::new(DCRTPolyHashSampler::<Keccak256>::new(key));
         let d = 3;
-        let bgg_sampler = BGGPublicKeySampler::new(hash_sampler, d);
+        let bgg_sampler = BGGPublicKeySampler::<_, DCRTPolyHashSampler<Keccak256>>::new(key, d);
 
         // Generate random tag for sampling
         let tag: u64 = rand::random();
@@ -192,9 +189,8 @@ mod tests {
 
         // Create a hash sampler and BGGPublicKeySampler to be reused
         let key: [u8; 32] = rand::random();
-        let hash_sampler = Arc::new(DCRTPolyHashSampler::<Keccak256>::new(key));
         let d = 3;
-        let bgg_sampler = BGGPublicKeySampler::new(hash_sampler, d);
+        let bgg_sampler = BGGPublicKeySampler::<_, DCRTPolyHashSampler<Keccak256>>::new(key, d);
 
         // Generate random tag for sampling
         let tag: u64 = rand::random();
@@ -232,9 +228,8 @@ mod tests {
 
         // Create a hash sampler and BGGPublicKeySampler to be reused
         let key: [u8; 32] = rand::random();
-        let hash_sampler = Arc::new(DCRTPolyHashSampler::<Keccak256>::new(key));
         let d = 3;
-        let bgg_sampler = BGGPublicKeySampler::new(hash_sampler, d);
+        let bgg_sampler = BGGPublicKeySampler::<_, DCRTPolyHashSampler<Keccak256>>::new(key, d);
 
         // Generate random tag for sampling
         let tag: u64 = rand::random();
@@ -282,9 +277,8 @@ mod tests {
 
         // Create a hash sampler and BGGPublicKeySampler to be reused
         let key: [u8; 32] = rand::random();
-        let hash_sampler = Arc::new(DCRTPolyHashSampler::<Keccak256>::new(key));
         let d = 3;
-        let bgg_sampler = BGGPublicKeySampler::new(hash_sampler, d);
+        let bgg_sampler = BGGPublicKeySampler::<_, DCRTPolyHashSampler<Keccak256>>::new(key, d);
 
         // Generate random tag for sampling
         let tag: u64 = rand::random();
@@ -350,9 +344,8 @@ mod tests {
 
         // Create a hash sampler and BGGPublicKeySampler to be reused
         let key: [u8; 32] = rand::random();
-        let hash_sampler = Arc::new(DCRTPolyHashSampler::<Keccak256>::new(key));
         let d = 3;
-        let bgg_sampler = BGGPublicKeySampler::new(hash_sampler, d);
+        let bgg_sampler = BGGPublicKeySampler::<_, DCRTPolyHashSampler<Keccak256>>::new(key, d);
 
         // Generate random tag for sampling
         let tag: u64 = rand::random();
@@ -418,9 +411,8 @@ mod tests {
 
         // Create a hash sampler and BGGPublicKeySampler to be reused
         let key: [u8; 32] = rand::random();
-        let hash_sampler = Arc::new(DCRTPolyHashSampler::<Keccak256>::new(key));
         let d = 3;
-        let bgg_sampler = BGGPublicKeySampler::new(hash_sampler, d);
+        let bgg_sampler = BGGPublicKeySampler::<_, DCRTPolyHashSampler<Keccak256>>::new(key, d);
 
         // Generate random tag for sampling
         let tag: u64 = rand::random();

--- a/src/io/eval.rs
+++ b/src/io/eval.rs
@@ -12,24 +12,18 @@ impl<M> Obfuscation<M>
 where
     M: PolyMatrix,
 {
-    pub fn eval<SH, ST>(
-        &self,
-        obf_params: ObfuscationParams<M>,
-        mut sampler_hash: SH,
-        inputs: &[bool],
-    ) -> Vec<bool>
+    pub fn eval<SH, ST>(&self, obf_params: ObfuscationParams<M>, inputs: &[bool]) -> Vec<bool>
     where
         SH: PolyHashSampler<[u8; 32], M = M>,
         ST: PolyTrapdoorSampler<M = M>,
     {
-        sampler_hash.set_key(self.hash_key);
         let params = Arc::new(obf_params.params.clone());
         let d = obf_params.d;
         let d1 = d + 1;
-        let sampler = Arc::new(sampler_hash);
+
         debug_assert_eq!(inputs.len(), obf_params.input_size);
-        let bgg_pubkey_sampler = BGGPublicKeySampler::new(sampler.clone(), d);
-        let public_data = PublicSampledData::sample(&obf_params, &bgg_pubkey_sampler);
+        let bgg_pubkey_sampler = BGGPublicKeySampler::<_, SH>::new(self.hash_key, d);
+        let public_data = PublicSampledData::<SH>::sample(&obf_params, self.hash_key);
         log_mem("Sampled public data");
         let packed_input_size = public_data.packed_input_size;
         let packed_output_size = public_data.packed_output_size;

--- a/src/io/obf.rs
+++ b/src/io/obf.rs
@@ -20,7 +20,6 @@ use std::sync::Arc;
 pub fn obfuscate<M, SU, SH, ST, R>(
     obf_params: ObfuscationParams<M>,
     sampler_uniform: SU,
-    mut sampler_hash: SH,
     sampler_trapdoor: ST,
     hardcoded_key: M::P,
     rng: &mut R,
@@ -39,10 +38,11 @@ where
     debug_assert_eq!(public_circuit.num_input(), (2 * log_base_q) + obf_params.input_size);
     let d = obf_params.d;
     let hash_key = rng.random::<[u8; 32]>();
-    sampler_hash.set_key(hash_key);
+    // let sampler_hash  =SH::n
+    // sampler_hash.set_key(hash_key);
     let sampler_uniform = Arc::new(sampler_uniform);
-    let bgg_pubkey_sampler = BGGPublicKeySampler::new(Arc::new(sampler_hash), d);
-    let public_data = PublicSampledData::sample(&obf_params, &bgg_pubkey_sampler);
+    let bgg_pubkey_sampler = BGGPublicKeySampler::<_, SH>::new(hash_key, d);
+    let public_data = PublicSampledData::<SH>::sample(&obf_params, hash_key);
     log_mem("Sampled public data");
 
     let packed_input_size = public_data.packed_input_size;

--- a/src/io/params.rs
+++ b/src/io/params.rs
@@ -13,4 +13,5 @@ pub struct ObfuscationParams<M: PolyMatrix> {
     pub encoding_sigma: f64,
     pub hardcoded_key_sigma: f64,
     pub p_sigma: f64,
+    pub trapdoor_sigma: f64,
 }

--- a/src/poly/dcrt/poly.rs
+++ b/src/poly/dcrt/poly.rs
@@ -396,7 +396,11 @@ impl SubAssign<&DCRTPoly> for DCRTPoly {
 #[cfg(feature = "test")]
 mod tests {
     use super::*;
-    use crate::poly::{dcrt::DCRTPolyUniformSampler, sampler::DistType, PolyParams};
+    use crate::poly::{
+        dcrt::DCRTPolyUniformSampler,
+        sampler::{DistType, PolyUniformSampler},
+        PolyParams,
+    };
     use rand::prelude::*;
 
     #[test]

--- a/src/poly/dcrt/sampler/trapdoor/sampler.rs
+++ b/src/poly/dcrt/sampler/trapdoor/sampler.rs
@@ -24,17 +24,18 @@ pub struct DCRTPolyTrapdoorSampler {
     c: f64,
 }
 
-impl DCRTPolyTrapdoorSampler {
-    pub fn new(params: &DCRTPolyParams, sigma: f64) -> Self {
+impl PolyTrapdoorSampler for DCRTPolyTrapdoorSampler {
+    type M = DCRTPolyMatrix;
+    type Trapdoor = DCRTTrapdoor;
+
+    fn new(
+        params: &<<Self::M as crate::poly::PolyMatrix>::P as crate::poly::Poly>::Params,
+        sigma: f64,
+    ) -> Self {
         let base = 1 << params.base_bits();
         let c = (base as f64 + 1.0) * SIGMA;
         Self { sigma, base, c }
     }
-}
-
-impl PolyTrapdoorSampler for DCRTPolyTrapdoorSampler {
-    type M = DCRTPolyMatrix;
-    type Trapdoor = DCRTTrapdoor;
 
     fn trapdoor(
         &self,

--- a/src/poly/dcrt/sampler/uniform.rs
+++ b/src/poly/dcrt/sampler/uniform.rs
@@ -1,7 +1,7 @@
 use crate::{
     parallel_iter,
     poly::{
-        dcrt::{DCRTPoly, DCRTPolyMatrix, DCRTPolyParams},
+        dcrt::{DCRTPoly, DCRTPolyMatrix},
         sampler::{DistType, PolyUniformSampler},
         Poly, PolyMatrix, PolyParams,
     },
@@ -19,12 +19,18 @@ impl Default for DCRTPolyUniformSampler {
     }
 }
 
-impl DCRTPolyUniformSampler {
-    pub fn new() -> Self {
+impl PolyUniformSampler for DCRTPolyUniformSampler {
+    type M = DCRTPolyMatrix;
+
+    fn new() -> Self {
         Self {}
     }
 
-    pub fn sample_poly(&self, params: &DCRTPolyParams, dist: &DistType) -> DCRTPoly {
+    fn sample_poly(
+        &self,
+        params: &<<Self::M as PolyMatrix>::P as Poly>::Params,
+        dist: &DistType,
+    ) -> <Self::M as PolyMatrix>::P {
         let sampled_poly = match dist {
             DistType::FinRingDist => ffi::DCRTPolyGenFromDug(
                 params.ring_dimension(),
@@ -48,10 +54,6 @@ impl DCRTPolyUniformSampler {
         }
         DCRTPoly::new(sampled_poly)
     }
-}
-
-impl PolyUniformSampler for DCRTPolyUniformSampler {
-    type M = DCRTPolyMatrix;
 
     fn sample_uniform(
         &self,
@@ -100,6 +102,7 @@ impl PolyUniformSampler for DCRTPolyUniformSampler {
 #[cfg(feature = "test")]
 mod tests {
     use super::*;
+    use crate::poly::dcrt::DCRTPolyParams;
 
     #[test]
     fn test_ring_dist() {

--- a/src/poly/enc.rs
+++ b/src/poly/enc.rs
@@ -36,7 +36,7 @@ mod tests {
     use crate::poly::{
         dcrt::{DCRTPolyMatrix, DCRTPolyParams, DCRTPolyUniformSampler},
         enc::rlwe_encrypt,
-        sampler::DistType,
+        sampler::{DistType, PolyUniformSampler},
         Poly, PolyMatrix,
     };
 

--- a/src/poly/sampler.rs
+++ b/src/poly/sampler.rs
@@ -19,6 +19,9 @@ pub enum DistType {
 /// Trait for sampling a polynomial based on a hash function.
 pub trait PolyHashSampler<K: AsRef<[u8]>> {
     type M: PolyMatrix;
+
+    fn new() -> Self;
+
     /// Samples a matrix of ring elements from a pseudorandom source defined by a hash function `H`
     /// Compute H(key || tag || i)
     ///
@@ -26,18 +29,24 @@ pub trait PolyHashSampler<K: AsRef<[u8]>> {
     fn sample_hash<B: AsRef<[u8]>>(
         &self,
         params: &<<Self::M as PolyMatrix>::P as Poly>::Params,
+        key: [u8; 32],
         tag: B,
         nrow: usize,
         ncol: usize,
         dist: DistType,
     ) -> Self::M;
-
-    // Set the key of the sampler.
-    fn set_key(&mut self, key: K);
 }
 
 pub trait PolyUniformSampler {
     type M: PolyMatrix;
+
+    fn new() -> Self;
+
+    fn sample_poly(
+        &self,
+        params: &<<Self::M as PolyMatrix>::P as Poly>::Params,
+        dist: &DistType,
+    ) -> <Self::M as PolyMatrix>::P;
 
     fn sample_uniform(
         &self,
@@ -52,11 +61,14 @@ pub trait PolyTrapdoorSampler {
     type M: PolyMatrix;
     type Trapdoor;
 
+    fn new(params: &<<Self::M as PolyMatrix>::P as Poly>::Params, sigma: f64) -> Self;
+
     fn trapdoor(
         &self,
         params: &<<Self::M as PolyMatrix>::P as Poly>::Params,
         size: usize,
     ) -> (Self::Trapdoor, Self::M);
+
     fn preimage(
         &self,
         params: &<<Self::M as PolyMatrix>::P as Poly>::Params,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -4,7 +4,7 @@ use std::{thread, time};
 
 use crate::poly::{
     dcrt::{DCRTPoly, DCRTPolyParams, DCRTPolyUniformSampler},
-    sampler::DistType,
+    sampler::{DistType, PolyUniformSampler},
     Poly,
 };
 use memory_stats::memory_stats;

--- a/tests/test_bgg_pubkey.rs
+++ b/tests/test_bgg_pubkey.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use diamond_io::{
     bgg::{circuit::PolyCircuit, sampler::BGGPublicKeySampler, BggPublicKey, DigitsToInt},
     io::utils::build_final_bits_circuit,
@@ -39,18 +37,18 @@ fn test_build_final_step_circuit() {
     }
 
     let mut rng = rand::rng();
-    let mut hash_sampler = DCRTPolyHashSampler::<Keccak256>::new([0; 32]);
     let hash_key = rng.random::<[u8; 32]>();
-    hash_sampler.set_key(hash_key);
     let d = 1;
     let sampler_uniform = DCRTPolyUniformSampler::new();
+    let hash_sampler = DCRTPolyHashSampler::<Keccak256>::new();
     let hardcoded_key = sampler_uniform.sample_uniform(&params, 1, 1, DistType::BitDist);
     log_mem("Sampled hardcoded_key_matrix");
 
     let t_bar_matrix = sampler_uniform.sample_uniform(&params, 1, 1, DistType::FinRingDist);
     log_mem("Sampled t_bar_matrix");
 
-    let a_rlwe_bar = hash_sampler.sample_hash(&params, "TEST_RLWE_A", 1, 1, DistType::FinRingDist);
+    let a_rlwe_bar =
+        hash_sampler.sample_hash(&params, hash_key, "TEST_RLWE_A", 1, 1, DistType::FinRingDist);
     let hardcoded_key_sigma = 40615715852990820734.97011;
 
     let b = rlwe_encrypt(
@@ -79,7 +77,8 @@ fn test_build_final_step_circuit() {
     let log_base_q = params.modulus_digits();
     let packed_input_size = input_size.div_ceil(dim) + 1;
 
-    let bgg_pubkey_sampler = BGGPublicKeySampler::new(Arc::new(hash_sampler), d);
+    let bgg_pubkey_sampler =
+        BGGPublicKeySampler::<_, DCRTPolyHashSampler<Keccak256>>::new(hash_key, d);
     let reveal_plaintexts = [vec![true; packed_input_size - 1], vec![false; 1]].concat();
     let pubkeys = bgg_pubkey_sampler.sample(&params, b"BGG_PUBKEY_INPUT:", &reveal_plaintexts);
     log_mem("Sampled pubkeys");

--- a/tests/test_io_dummy_param.rs
+++ b/tests/test_io_dummy_param.rs
@@ -8,7 +8,7 @@ mod test {
                 DCRTPoly, DCRTPolyHashSampler, DCRTPolyMatrix, DCRTPolyParams,
                 DCRTPolyTrapdoorSampler, DCRTPolyUniformSampler, FinRingElem,
             },
-            sampler::DistType,
+            sampler::{DistType, PolyTrapdoorSampler, PolyUniformSampler},
             Poly, PolyElem, PolyParams,
         },
         utils::init_tracing,
@@ -59,14 +59,12 @@ mod test {
         };
 
         let sampler_uniform = DCRTPolyUniformSampler::new();
-        let sampler_hash = DCRTPolyHashSampler::<Keccak256>::new([0; 32]);
         let sampler_trapdoor = DCRTPolyTrapdoorSampler::new(&params, SIGMA);
         let mut rng = rand::rng();
         let hardcoded_key = sampler_uniform.sample_poly(&params, &DistType::BitDist);
-        let obfuscation = obfuscate::<DCRTPolyMatrix, _, _, _, _>(
+        let obfuscation = obfuscate::<DCRTPolyMatrix, _, DCRTPolyHashSampler<Keccak256>, _, _>(
             obf_params.clone(),
             sampler_uniform,
-            sampler_hash,
             sampler_trapdoor,
             hardcoded_key.clone(),
             &mut rng,
@@ -76,9 +74,8 @@ mod test {
 
         let bool_in = rng.random::<bool>();
         let input = [bool_in];
-        let sampler_hash = DCRTPolyHashSampler::<Keccak256>::new([0; 32]);
-        let output =
-            obfuscation.eval::<_, DCRTPolyTrapdoorSampler>(obf_params, sampler_hash, &input);
+        let output = obfuscation
+            .eval::<DCRTPolyHashSampler<Keccak256>, DCRTPolyTrapdoorSampler>(obf_params, &input);
         let total_time = start_time.elapsed();
         info!("Time for evaluation: {:?}", total_time - obfuscation_time);
         info!("Total time: {:?}", total_time);

--- a/tests/test_io_dummy_param.rs
+++ b/tests/test_io_dummy_param.rs
@@ -8,7 +8,7 @@ mod test {
                 DCRTPoly, DCRTPolyHashSampler, DCRTPolyMatrix, DCRTPolyParams,
                 DCRTPolyTrapdoorSampler, DCRTPolyUniformSampler, FinRingElem,
             },
-            sampler::{DistType, PolyTrapdoorSampler, PolyUniformSampler},
+            sampler::{DistType, PolyUniformSampler},
             Poly, PolyElem, PolyParams,
         },
         utils::init_tracing,
@@ -18,8 +18,6 @@ mod test {
     use rand::Rng;
     use std::sync::Arc;
     use tracing::info;
-
-    const SIGMA: f64 = 4.578;
 
     #[test]
     fn test_io_just_mul_enc_and_and_bit() {
@@ -56,19 +54,19 @@ mod test {
             encoding_sigma: 0.0,
             hardcoded_key_sigma: 0.0,
             p_sigma: 0.0,
+            trapdoor_sigma: 4.578,
         };
 
         let sampler_uniform = DCRTPolyUniformSampler::new();
-        let sampler_trapdoor = DCRTPolyTrapdoorSampler::new(&params, SIGMA);
         let mut rng = rand::rng();
         let hardcoded_key = sampler_uniform.sample_poly(&params, &DistType::BitDist);
-        let obfuscation = obfuscate::<DCRTPolyMatrix, _, DCRTPolyHashSampler<Keccak256>, _, _>(
-            obf_params.clone(),
-            sampler_uniform,
-            sampler_trapdoor,
-            hardcoded_key.clone(),
-            &mut rng,
-        );
+        let obfuscation = obfuscate::<
+            DCRTPolyMatrix,
+            DCRTPolyUniformSampler,
+            DCRTPolyHashSampler<Keccak256>,
+            DCRTPolyTrapdoorSampler,
+            _,
+        >(obf_params.clone(), hardcoded_key.clone(), &mut rng);
         let obfuscation_time = start_time.elapsed();
         info!("Time to obfuscate: {:?}", obfuscation_time);
 

--- a/tests/test_io_middle_param.rs
+++ b/tests/test_io_middle_param.rs
@@ -8,7 +8,7 @@ mod test {
                 DCRTPoly, DCRTPolyHashSampler, DCRTPolyMatrix, DCRTPolyParams,
                 DCRTPolyTrapdoorSampler, DCRTPolyUniformSampler, FinRingElem,
             },
-            sampler::DistType,
+            sampler::{DistType, PolyTrapdoorSampler, PolyUniformSampler},
             Poly, PolyElem, PolyParams,
         },
         utils::init_tracing,
@@ -62,14 +62,12 @@ mod test {
         };
 
         let sampler_uniform = DCRTPolyUniformSampler::new();
-        let sampler_hash = DCRTPolyHashSampler::<Keccak256>::new([0; 32]);
         let sampler_trapdoor = DCRTPolyTrapdoorSampler::new(&params, SIGMA);
         let mut rng = rand::rng();
         let hardcoded_key = sampler_uniform.sample_poly(&params, &DistType::BitDist);
-        let obfuscation = obfuscate::<DCRTPolyMatrix, _, _, _, _>(
+        let obfuscation = obfuscate::<DCRTPolyMatrix, _, DCRTPolyHashSampler<Keccak256>, _, _>(
             obf_params.clone(),
             sampler_uniform,
-            sampler_hash,
             sampler_trapdoor,
             hardcoded_key.clone(),
             &mut rng,
@@ -79,9 +77,8 @@ mod test {
 
         let bool_in = rng.random::<bool>();
         let input = [bool_in];
-        let sampler_hash = DCRTPolyHashSampler::<Keccak256>::new([0; 32]);
-        let output =
-            obfuscation.eval::<_, DCRTPolyTrapdoorSampler>(obf_params, sampler_hash, &input);
+        let output = obfuscation
+            .eval::<DCRTPolyHashSampler<Keccak256>, DCRTPolyTrapdoorSampler>(obf_params, &input);
         let total_time = start_time.elapsed();
         info!("Time for evaluation: {:?}", total_time - obfuscation_time);
         info!("Total time: {:?}", total_time);

--- a/tests/test_io_middle_param.rs
+++ b/tests/test_io_middle_param.rs
@@ -8,7 +8,7 @@ mod test {
                 DCRTPoly, DCRTPolyHashSampler, DCRTPolyMatrix, DCRTPolyParams,
                 DCRTPolyTrapdoorSampler, DCRTPolyUniformSampler, FinRingElem,
             },
-            sampler::{DistType, PolyTrapdoorSampler, PolyUniformSampler},
+            sampler::{DistType, PolyUniformSampler},
             Poly, PolyElem, PolyParams,
         },
         utils::init_tracing,
@@ -19,8 +19,6 @@ mod test {
     use rand::Rng;
     use std::sync::Arc;
     use tracing::info;
-
-    const SIGMA: f64 = 4.578;
 
     #[test]
     fn test_io_just_mul_enc_and_bit_middle_params() {
@@ -59,19 +57,19 @@ mod test {
             encoding_sigma: 15.82764,
             hardcoded_key_sigma: 15.82764,
             p_sigma: 15.82764,
+            trapdoor_sigma: 4.578,
         };
 
         let sampler_uniform = DCRTPolyUniformSampler::new();
-        let sampler_trapdoor = DCRTPolyTrapdoorSampler::new(&params, SIGMA);
         let mut rng = rand::rng();
         let hardcoded_key = sampler_uniform.sample_poly(&params, &DistType::BitDist);
-        let obfuscation = obfuscate::<DCRTPolyMatrix, _, DCRTPolyHashSampler<Keccak256>, _, _>(
-            obf_params.clone(),
-            sampler_uniform,
-            sampler_trapdoor,
-            hardcoded_key.clone(),
-            &mut rng,
-        );
+        let obfuscation = obfuscate::<
+            DCRTPolyMatrix,
+            DCRTPolyUniformSampler,
+            DCRTPolyHashSampler<Keccak256>,
+            DCRTPolyTrapdoorSampler,
+            _,
+        >(obf_params.clone(), hardcoded_key.clone(), &mut rng);
         let obfuscation_time = start_time.elapsed();
         info!("Time to obfuscate: {:?}", obfuscation_time);
 

--- a/tests/test_io_real_param.rs
+++ b/tests/test_io_real_param.rs
@@ -8,7 +8,7 @@ mod test {
                 DCRTPoly, DCRTPolyHashSampler, DCRTPolyMatrix, DCRTPolyParams,
                 DCRTPolyTrapdoorSampler, DCRTPolyUniformSampler, FinRingElem,
             },
-            sampler::{DistType, PolyTrapdoorSampler, PolyUniformSampler},
+            sampler::{DistType, PolyUniformSampler},
             Poly, PolyElem, PolyParams,
         },
         utils::init_tracing,
@@ -19,8 +19,6 @@ mod test {
     use rand::Rng;
     use std::sync::Arc;
     use tracing::info;
-
-    const SIGMA: f64 = 4.578;
 
     #[test]
     #[ignore]
@@ -54,19 +52,19 @@ mod test {
             encoding_sigma: 12.05698,
             hardcoded_key_sigma: 40615715852990820734.97011,
             p_sigma: 12.05698,
+            trapdoor_sigma: 4.578,
         };
 
         let sampler_uniform = DCRTPolyUniformSampler::new();
-        let sampler_trapdoor = DCRTPolyTrapdoorSampler::new(&params, SIGMA);
         let mut rng = rand::rng();
         let hardcoded_key = sampler_uniform.sample_poly(&params, &DistType::BitDist);
-        let obfuscation = obfuscate::<DCRTPolyMatrix, _, DCRTPolyHashSampler<Keccak256>, _, _>(
-            obf_params.clone(),
-            sampler_uniform,
-            sampler_trapdoor,
-            hardcoded_key.clone(),
-            &mut rng,
-        );
+        let obfuscation = obfuscate::<
+            DCRTPolyMatrix,
+            DCRTPolyUniformSampler,
+            DCRTPolyHashSampler<Keccak256>,
+            DCRTPolyTrapdoorSampler,
+            _,
+        >(obf_params.clone(), hardcoded_key.clone(), &mut rng);
         let obfuscation_time = start_time.elapsed();
         info!("Time to obfuscate: {:?}", obfuscation_time);
 

--- a/tests/test_io_real_param.rs
+++ b/tests/test_io_real_param.rs
@@ -8,7 +8,7 @@ mod test {
                 DCRTPoly, DCRTPolyHashSampler, DCRTPolyMatrix, DCRTPolyParams,
                 DCRTPolyTrapdoorSampler, DCRTPolyUniformSampler, FinRingElem,
             },
-            sampler::DistType,
+            sampler::{DistType, PolyTrapdoorSampler, PolyUniformSampler},
             Poly, PolyElem, PolyParams,
         },
         utils::init_tracing,
@@ -57,14 +57,12 @@ mod test {
         };
 
         let sampler_uniform = DCRTPolyUniformSampler::new();
-        let sampler_hash = DCRTPolyHashSampler::<Keccak256>::new([0; 32]);
         let sampler_trapdoor = DCRTPolyTrapdoorSampler::new(&params, SIGMA);
         let mut rng = rand::rng();
         let hardcoded_key = sampler_uniform.sample_poly(&params, &DistType::BitDist);
-        let obfuscation = obfuscate::<DCRTPolyMatrix, _, _, _, _>(
+        let obfuscation = obfuscate::<DCRTPolyMatrix, _, DCRTPolyHashSampler<Keccak256>, _, _>(
             obf_params.clone(),
             sampler_uniform,
-            sampler_hash,
             sampler_trapdoor,
             hardcoded_key.clone(),
             &mut rng,
@@ -74,9 +72,8 @@ mod test {
 
         let bool_in = rng.random::<bool>();
         let input = [bool_in];
-        let sampler_hash = DCRTPolyHashSampler::<Keccak256>::new([0; 32]);
-        let output =
-            obfuscation.eval::<_, DCRTPolyTrapdoorSampler>(obf_params, sampler_hash, &input);
+        let output = obfuscation
+            .eval::<DCRTPolyHashSampler<Keccak256>, DCRTPolyTrapdoorSampler>(obf_params, &input);
         let total_time = start_time.elapsed();
         info!("Time for evaluation: {:?}", total_time - obfuscation_time);
         info!("Total time: {:?}", total_time);


### PR DESCRIPTION
initiate sampler as a trait and have cleaner interface for most abstracted method `obfuscate` and `evaluate`