### PR TITLE
Feat: just in time artifacts loading during evaluation phase

### DIFF
--- a/dio/src/main.rs
+++ b/dio/src/main.rs
@@ -9,12 +9,12 @@ use diamond_io::{
         utils::build_final_digits_circuit,
     },
     poly::{
+        Poly, PolyElem, PolyParams,
         dcrt::{
             DCRTPoly, DCRTPolyHashSampler, DCRTPolyMatrix, DCRTPolyParams, DCRTPolyTrapdoorSampler,
             DCRTPolyUniformSampler, FinRingElem,
         },
         sampler::{DistType, PolyUniformSampler},
-        Poly, PolyElem, PolyParams,
     },
     utils::{calculate_directory_size, init_tracing},
 };

--- a/dio/src/main.rs
+++ b/dio/src/main.rs
@@ -5,15 +5,16 @@ use config::{RunBenchConfig, SimBenchNormConfig};
 use diamond_io::utils::calculate_tmp_size;
 use diamond_io::{
     io::{
-        Obfuscation, obf::obfuscate, params::ObfuscationParams, utils::build_final_digits_circuit,
+        eval::evaluate, obf::obfuscate, params::ObfuscationParams,
+        utils::build_final_digits_circuit,
     },
     poly::{
-        Poly, PolyElem, PolyParams,
         dcrt::{
             DCRTPoly, DCRTPolyHashSampler, DCRTPolyMatrix, DCRTPolyParams, DCRTPolyTrapdoorSampler,
             DCRTPolyUniformSampler, FinRingElem,
         },
         sampler::{DistType, PolyUniformSampler},
+        Poly, PolyElem, PolyParams,
     },
     utils::{calculate_directory_size, init_tracing},
 };
@@ -28,7 +29,6 @@ use std::{
     path::{Path, PathBuf},
     sync::Arc,
 };
-use tokio;
 use tracing::info;
 
 pub mod circuit;
@@ -136,26 +136,15 @@ async fn main() {
             let input = dio_config.input;
             assert_eq!(input.len(), dio_config.input_size);
 
-            #[cfg(feature = "disk")]
-            let tmp_start_size = calculate_tmp_size();
             let start_time = std::time::Instant::now();
-            let obfuscation = Obfuscation::read_dir(&obf_params, &obf_dir);
-            let load_time = start_time.elapsed();
-            info!("Time to load obfuscation: {:?}", load_time);
-            #[cfg(feature = "disk")]
-            let tmp_end_size = calculate_tmp_size();
-            #[cfg(feature = "disk")]
-            log_mem(format!(
-                "Obfuscation size after loading: {} bytes",
-                tmp_end_size - tmp_start_size
-            ));
-            let start_time = std::time::Instant::now();
-            let output = obfuscation
-                .eval::<DCRTPolyHashSampler<Keccak256>, DCRTPolyTrapdoorSampler>(
-                    obf_params, &input,
-                );
+            let output = evaluate::<
+                DCRTPolyMatrix,
+                DCRTPolyHashSampler<Keccak256>,
+                DCRTPolyTrapdoorSampler,
+                _,
+            >(obf_params, &input, &obf_dir);
             let eval_time = start_time.elapsed();
-            let total_time = obfuscation_time + load_time + eval_time;
+            let total_time = obfuscation_time + eval_time;
             info!("Time for evaluation: {:?}", eval_time);
             info!("Total time: {:?}", total_time);
             if verify {

--- a/src/io/eval.rs
+++ b/src/io/eval.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "bgm")]
 use super::bgm::Player;
 
-use super::{params::ObfuscationParams, Obfuscation};
+use super::params::ObfuscationParams;
 use crate::{
     bgg::{sampler::BGGPublicKeySampler, BggEncoding, DigitsToInt},
     io::utils::{build_final_digits_circuit, sample_public_key_by_id, PublicSampledData},
@@ -16,520 +16,362 @@ use itertools::Itertools;
 use rayon::{iter::ParallelIterator, slice::ParallelSlice};
 use std::{path::Path, sync::Arc};
 
-impl<M> Obfuscation<M>
+pub fn evaluate<M, SH, ST, P>(
+    obf_params: ObfuscationParams<M>,
+    inputs: &[bool],
+    dir_path: P,
+) -> Vec<bool>
 where
     M: PolyMatrix,
+    SH: PolyHashSampler<[u8; 32], M = M>,
+    ST: PolyTrapdoorSampler<M = M>,
+    P: AsRef<Path>,
 {
-    pub fn read_dir<P: AsRef<Path> + Send + Sync>(
-        obf_params: &ObfuscationParams<M>,
-        dir_path: P,
-    ) -> Self {
-        let dir_path = dir_path.as_ref().to_path_buf();
-        // let b = M::read_from_files(&obf_params.params, 1, 1, &dir_path, "b");
+    #[cfg(feature = "bgm")]
+    let player = Player::new();
 
-        let dim = obf_params.params.ring_dimension() as usize;
-        let packed_input_size = obf_params.input_size.div_ceil(dim) + 1;
-        let d = obf_params.d;
-        let d1 = d + 1;
-        let log_base_q = obf_params.params.modulus_digits();
-        #[cfg(feature = "debug")]
-        let reveal_plaintexts = [vec![true; packed_input_size], vec![true; 1]].concat();
-        #[cfg(not(feature = "debug"))]
-        let reveal_plaintexts = [vec![true; packed_input_size], vec![false; 1]].concat();
-        let params = Arc::new(obf_params.params.clone());
-        let encodings_init = parallel_iter!(0..packed_input_size + 1)
-            .map(|idx| {
-                BggEncoding::read_from_files(
-                    params.as_ref(),
-                    d1,
-                    log_base_q,
-                    &dir_path,
-                    &format!("encoding_init_{idx}"),
-                    reveal_plaintexts[idx],
-                )
-            })
-            .collect::<Vec<_>>();
-
-        // let m_b = (2 * d1) * (2 + log_base_q);
-        // // let p_init = M::read_from_files(&obf_params.params, 1, m_b, &dir_path, "p_init");
-
-        // let level_size = (1u64 << obf_params.level_width) as usize;
-        // let depth = obf_params.input_size / obf_params.level_width;
-        // let m_preimages = parallel_iter!(0..depth)
-        //     .map(|level| {
-        //         parallel_iter!(0..level_size)
-        //             .map(|num| {
-        //                 M::read_from_files(
-        //                     params.as_ref(),
-        //                     m_b,
-        //                     m_b,
-        //                     &dir_path,
-        //                     &format!("m_preimage_{level}_{num}"),
-        //                 )
-        //             })
-        //             .collect::<Vec<_>>()
-        //     })
-        //     .collect::<Vec<_>>();
-        // let n_preimages = parallel_iter!(0..depth)
-        //     .map(|level| {
-        //         parallel_iter!(0..level_size)
-        //             .map(|num| {
-        //                 M::read_from_files(
-        //                     params.as_ref(),
-        //                     m_b,
-        //                     m_b,
-        //                     &dir_path,
-        //                     &format!("n_preimage_{level}_{num}"),
-        //                 )
-        //             })
-        //             .collect::<Vec<_>>()
-        //     })
-        //     .collect::<Vec<_>>();
-        // let k_columns = (1 + packed_input_size) * d1 * log_base_q;
-        // let k_preimages = parallel_iter!(0..depth)
-        //     .map(|level| {
-        //         parallel_iter!(0..level_size)
-        //             .map(|num| {
-        //                 M::read_from_files(
-        //                     params.as_ref(),
-        //                     m_b,
-        //                     k_columns,
-        //                     &dir_path,
-        //                     &format!("k_preimage_{level}_{num}"),
-        //                 )
-        //             })
-        //             .collect::<Vec<_>>()
-        //     })
-        //     .collect::<Vec<_>>();
-        // let packed_output_size = obf_params.public_circuit.num_output() / (2 * log_base_q);
-        // let final_preimage = M::read_from_files(
-        //     &obf_params.params,
-        //     m_b,
-        //     packed_output_size,
-        //     &dir_path,
-        //     "final_preimage",
-        // );
-        // let hash_key = {
-        //     let mut path = dir_path.clone();
-        //     path.push("hash_key");
-        //     let bytes = std::fs::read(&path).expect("Failed to read hash key file");
-        //     let mut hash_key = [0u8; 32];
-        //     hash_key.copy_from_slice(&bytes);
-        //     hash_key
-        // };
-        // #[cfg(feature = "debug")]
-        // let s_init = M::read_from_files(&obf_params.params, 1, d1, &dir_path, "s_init");
-
-        // #[cfg(feature = "debug")]
-        // let minus_t_bar = <<M as PolyMatrix>::P as Poly>::read_from_file(
-        //     &obf_params.params,
-        //     &dir_path,
-        //     "minus_t_bar",
-        // );
-
-        // #[cfg(feature = "debug")]
-        // let hardcoded_key = <<M as PolyMatrix>::P as Poly>::read_from_file(
-        //     &obf_params.params,
-        //     &dir_path,
-        //     "hardcoded_key",
-        // );
-
-        // #[cfg(feature = "debug")]
-        // let bs = parallel_iter!(0..depth + 1)
-        //     .map(|level| {
-        //         let mut b_nums = if level == 0 {
-        //             vec![M::zero(params.as_ref(), 2 * d1, m_b); level_size]
-        //         } else {
-        //             parallel_iter!(0..level_size)
-        //                 .map(|num| {
-        //                     M::read_from_files(
-        //                         params.as_ref(),
-        //                         2 * d1,
-        //                         m_b,
-        //                         &dir_path,
-        //                         &format!("b_{level}_{num}"),
-        //                     )
-        //                 })
-        //                 .collect::<Vec<_>>()
-        //         };
-        //         let b_star = M::read_from_files(
-        //             params.as_ref(),
-        //             2 * d1,
-        //             m_b,
-        //             &dir_path,
-        //             &format!("b_star_{level}"),
-        //         );
-        //         b_nums.push(b_star);
-        //         b_nums
-        //     })
-        //     .collect::<Vec<_>>();
-
-        Self {
-            // b,
-            encodings_init,
-            // p_init,
-            // m_preimages,
-            // n_preimages,
-            // k_preimages,
-            // hash_key,
-            // final_preimage,
-            // #[cfg(feature = "debug")]
-            // s_init,
-            // #[cfg(feature = "debug")]
-            // minus_t_bar,
-            // #[cfg(feature = "debug")]
-            // bs,
-            // #[cfg(feature = "debug")]
-            // hardcoded_key,
-        }
-    }
-
-    pub fn evaluate<SH, ST, P>(
-        &self,
-        obf_params: ObfuscationParams<M>,
-        inputs: &[bool],
-        dir_path: P,
-    ) -> Vec<bool>
-    where
-        SH: PolyHashSampler<[u8; 32], M = M>,
-        ST: PolyTrapdoorSampler<M = M>,
-        P: AsRef<Path>,
+    #[cfg(feature = "bgm")]
     {
-        #[cfg(feature = "bgm")]
-        let player = Player::new();
+        player.play_music("bgm/eval_bgm1.mp3");
+    }
+    let d = obf_params.d;
+    let d1 = d + 1;
+    let params = Arc::new(obf_params.params.clone());
+    let log_base_q = params.modulus_digits();
+    let dim = params.ring_dimension() as usize;
+    let m_b = (2 * d1) * (2 + log_base_q);
+    let dir_path = dir_path.as_ref().to_path_buf();
+    assert_eq!(inputs.len(), obf_params.input_size);
 
-        #[cfg(feature = "bgm")]
-        {
-            player.play_music("bgm/eval_bgm1.mp3");
-        }
-        let d = obf_params.d;
-        let d1 = d + 1;
-        let params = Arc::new(obf_params.params.clone());
-        let log_base_q = params.modulus_digits();
-        let dim = params.ring_dimension() as usize;
-        let m_b = (2 * d1) * (2 + log_base_q);
-        let dir_path = dir_path.as_ref().to_path_buf();
-        assert_eq!(inputs.len(), obf_params.input_size);
+    let hash_key = {
+        let mut path = dir_path.clone();
+        path.push("hash_key");
+        let bytes = std::fs::read(&path).expect("Failed to read hash key file");
+        let mut hash_key = [0u8; 32];
+        hash_key.copy_from_slice(&bytes);
+        hash_key
+    };
+    log_mem("hash_key loaded");
 
-        let hash_key = {
-            let mut path = dir_path.clone();
-            path.push("hash_key");
-            let bytes = std::fs::read(&path).expect("Failed to read hash key file");
-            let mut hash_key = [0u8; 32];
-            hash_key.copy_from_slice(&bytes);
-            hash_key
+    let bgg_pubkey_sampler = BGGPublicKeySampler::<_, SH>::new(hash_key, d);
+    let public_data = PublicSampledData::<SH>::sample(&obf_params, hash_key);
+    log_mem("Sampled public data");
+
+    let packed_input_size = public_data.packed_input_size;
+    let packed_output_size = public_data.packed_output_size;
+    let (mut ps, mut encodings) = (vec![], vec![]);
+    let p_init = M::read_from_files(&obf_params.params, 1, m_b, &dir_path, "p_init");
+    log_mem("p_init loaded");
+
+    #[cfg(feature = "debug")]
+    let reveal_plaintexts = [vec![true; packed_input_size], vec![true; 1]].concat();
+    #[cfg(not(feature = "debug"))]
+    let reveal_plaintexts = [vec![true; packed_input_size], vec![false; 1]].concat();
+    let params = Arc::new(obf_params.params.clone());
+    let encodings_init = parallel_iter!(0..packed_input_size + 1)
+        .map(|idx| {
+            BggEncoding::<M>::read_from_files(
+                params.as_ref(),
+                d1,
+                log_base_q,
+                &dir_path,
+                &format!("encoding_init_{idx}"),
+                reveal_plaintexts[idx],
+            )
+        })
+        .collect::<Vec<_>>();
+
+    ps.push(p_init.clone());
+    encodings.push(encodings_init.clone());
+
+    let level_width = obf_params.level_width;
+    #[cfg(feature = "debug")]
+    let level_size = (1u64 << obf_params.level_width) as usize;
+    assert!(inputs.len() % level_width == 0);
+    let depth = obf_params.input_size / level_width;
+
+    #[cfg(feature = "debug")]
+    let reveal_plaintexts = [vec![true; packed_input_size - 1], vec![true; 1]].concat();
+    #[cfg(not(feature = "debug"))]
+    let reveal_plaintexts = [vec![true; packed_input_size - 1], vec![false; 1]].concat();
+    let pub_key_init = sample_public_key_by_id(&bgg_pubkey_sampler, &params, 0, &reveal_plaintexts);
+    log_mem("Sampled pub_key_init");
+
+    let mut pub_key_cur = pub_key_init;
+
+    #[cfg(feature = "debug")]
+    let s_init = M::read_from_files(&obf_params.params, 1, d1, &dir_path, "s_init");
+
+    #[cfg(feature = "debug")]
+    let minus_t_bar = <<M as PolyMatrix>::P as Poly>::read_from_file(
+        &obf_params.params,
+        &dir_path,
+        "minus_t_bar",
+    );
+
+    #[cfg(feature = "debug")]
+    let bs = parallel_iter!(0..depth + 1)
+        .map(|level| {
+            let mut b_nums = if level == 0 {
+                vec![M::zero(params.as_ref(), 2 * d1, m_b); level_size]
+            } else {
+                parallel_iter!(0..level_size)
+                    .map(|num| {
+                        M::read_from_files(
+                            params.as_ref(),
+                            2 * d1,
+                            m_b,
+                            &dir_path,
+                            &format!("b_{level}_{num}"),
+                        )
+                    })
+                    .collect::<Vec<_>>()
+            };
+            let b_star = M::read_from_files(
+                params.as_ref(),
+                2 * d1,
+                m_b,
+                &dir_path,
+                &format!("b_star_{level}"),
+            );
+            b_nums.push(b_star);
+            b_nums
+        })
+        .collect::<Vec<_>>();
+
+    #[cfg(feature = "debug")]
+    if obf_params.encoding_sigma == 0.0 &&
+        obf_params.hardcoded_key_sigma == 0.0 &&
+        obf_params.p_sigma == 0.0
+    {
+        let expected_p_init = {
+            let s_connect = s_init.concat_columns(&[&s_init]);
+            s_connect * &bs[0][level_size]
         };
-        log_mem("hash_key loaded");
+        assert_eq!(p_init, expected_p_init);
+        let inserted_poly_gadget = {
+            let zero = <M::P as Poly>::const_zero(&params);
+            let one = <M::P as Poly>::const_one(&params);
+            let mut polys = vec![];
+            polys.push(one);
+            for _ in 0..(packed_input_size - 1) {
+                polys.push(zero.clone());
+            }
+            polys.push(minus_t_bar.clone());
+            let gadget_d1 = M::gadget_matrix(&params, d1);
+            M::from_poly_vec_row(&params, polys).tensor(&gadget_d1)
+        };
+        let expected_encoding_init = s_init.clone() *
+            &(pub_key_cur[0].concat_matrix(&pub_key_cur[1..]) - inserted_poly_gadget);
+        assert_eq!(encodings[0][0].concat_vector(&encodings[0][1..]), expected_encoding_init);
+    }
+    let nums: Vec<u64> = inputs
+        .chunks(level_width)
+        .map(|chunk| {
+            chunk.iter().enumerate().fold(0u64, |acc, (i, &bit)| acc + ((bit as u64) << i))
+        })
+        .collect();
+    debug_assert_eq!(nums.len(), depth);
 
-        let bgg_pubkey_sampler = BGGPublicKeySampler::<_, SH>::new(hash_key, d);
-        let public_data = PublicSampledData::<SH>::sample(&obf_params, hash_key);
-        log_mem("Sampled public data");
-
-        let packed_input_size = public_data.packed_input_size;
-        let packed_output_size = public_data.packed_output_size;
-        let (mut ps, mut encodings) = (vec![], vec![]);
-        let p_init = M::read_from_files(&obf_params.params, 1, m_b, &dir_path, "p_init");
-        log_mem("p_init loaded");
-
-        ps.push(p_init.clone());
-        encodings.push(self.encodings_init.clone());
-
-        let level_width = obf_params.level_width;
-        #[cfg(feature = "debug")]
-        let level_size = (1u64 << obf_params.level_width) as usize;
-        assert!(inputs.len() % level_width == 0);
-        let depth = obf_params.input_size / level_width;
-
-        #[cfg(feature = "debug")]
-        let reveal_plaintexts = [vec![true; packed_input_size - 1], vec![true; 1]].concat();
-        #[cfg(not(feature = "debug"))]
-        let reveal_plaintexts = [vec![true; packed_input_size - 1], vec![false; 1]].concat();
-        let pub_key_init =
-            sample_public_key_by_id(&bgg_pubkey_sampler, &params, 0, &reveal_plaintexts);
-        log_mem("Sampled pub_key_init");
-
-        let mut pub_key_cur = pub_key_init;
-
-        #[cfg(feature = "debug")]
-        let s_init = M::read_from_files(&obf_params.params, 1, d1, &dir_path, "s_init");
-
-        #[cfg(feature = "debug")]
-        let minus_t_bar = <<M as PolyMatrix>::P as Poly>::read_from_file(
-            &obf_params.params,
+    for (level, num) in nums.iter().enumerate() {
+        let m = M::read_from_files(
+            params.as_ref(),
+            m_b,
+            m_b,
             &dir_path,
-            "minus_t_bar",
+            &format!("m_preimage_{level}_{num}"),
         );
-
-        #[cfg(feature = "debug")]
-        let bs = parallel_iter!(0..depth + 1)
-            .map(|level| {
-                let mut b_nums = if level == 0 {
-                    vec![M::zero(params.as_ref(), 2 * d1, m_b); level_size]
-                } else {
-                    parallel_iter!(0..level_size)
-                        .map(|num| {
-                            M::read_from_files(
-                                params.as_ref(),
-                                2 * d1,
-                                m_b,
-                                &dir_path,
-                                &format!("b_{level}_{num}"),
-                            )
-                        })
-                        .collect::<Vec<_>>()
-                };
-                let b_star = M::read_from_files(
-                    params.as_ref(),
-                    2 * d1,
-                    m_b,
-                    &dir_path,
-                    &format!("b_star_{level}"),
-                );
-                b_nums.push(b_star);
-                b_nums
-            })
-            .collect::<Vec<_>>();
-
+        log_mem(format!("m at {} loaded", level));
+        let q = ps[level].clone() * m;
+        log_mem(format!("q at {} computed", level));
+        let n = M::read_from_files(
+            params.as_ref(),
+            m_b,
+            m_b,
+            &dir_path,
+            &format!("n_preimage_{level}_{num}"),
+        );
+        log_mem(format!("n at {} loaded", level));
+        let p = q.clone() * n;
+        log_mem(format!("p at {} computed", level));
+        let k_columns = (1 + packed_input_size) * d1 * log_base_q;
+        let k = M::read_from_files(
+            params.as_ref(),
+            m_b,
+            k_columns,
+            &dir_path,
+            &format!("k_preimage_{level}_{num}"),
+        );
+        log_mem(format!("k at {} loaded", level));
+        let v = q.clone() * k;
+        log_mem(format!("v at {} computed", level));
+        let new_encode_vec = {
+            let rg = &public_data.rgs[*num as usize];
+            let encode_vec = encodings[level][0].concat_vector(&encodings[level][1..]);
+            let packed_input_size = obf_params.input_size.div_ceil(dim) + 1;
+            encode_vec.mul_tensor_identity_decompose(rg, packed_input_size + 1) + v
+        };
+        log_mem(format!("new_encode_vec at {} computed", level));
+        let mut new_encodings = vec![];
+        let inserted_poly_index = 1 + (level * level_width) / dim;
+        let pub_key_level =
+            sample_public_key_by_id(&bgg_pubkey_sampler, &params, level + 1, &reveal_plaintexts);
+        log_mem(format!("pub_key_level at {} computed", level));
+        for (j, encode) in encodings[level].iter().enumerate() {
+            let m = d1 * log_base_q;
+            let new_vec = new_encode_vec.slice_columns(j * m, (j + 1) * m);
+            log_mem(format!("new_vec at {}, {} computed", level, j));
+            let plaintext = if j == inserted_poly_index {
+                let inserted_coeff_indices =
+                    (0..level_width).map(|i| (i + (level * level_width)) % dim).collect_vec();
+                let mut coeffs = encode.plaintext.as_ref().unwrap().coeffs();
+                let num_bits: Vec<bool> = (0..level_width).map(|i| (num >> i) & 1 == 1).collect();
+                debug_assert_eq!(num_bits.len(), level_width);
+                for (i, coeff_idx) in inserted_coeff_indices.iter().enumerate() {
+                    let bit = num_bits[i];
+                    if bit {
+                        coeffs[*coeff_idx] = <M::P as Poly>::Elem::one(&params.modulus());
+                    }
+                }
+                Some(M::P::from_coeffs(&params, &coeffs))
+            } else {
+                encode.plaintext.clone()
+            };
+            log_mem(format!("plaintext at {}, {} computed", level, j));
+            let new_encode: BggEncoding<M> =
+                BggEncoding::new(new_vec, pub_key_level[j].clone(), plaintext);
+            log_mem(format!("new_encode at {}, {} computed", level, j));
+            new_encodings.push(new_encode);
+        }
+        ps.push(p.clone());
+        pub_key_cur = pub_key_level;
+        encodings.push(new_encodings);
         #[cfg(feature = "debug")]
         if obf_params.encoding_sigma == 0.0 &&
             obf_params.hardcoded_key_sigma == 0.0 &&
             obf_params.p_sigma == 0.0
         {
-            let expected_p_init = {
-                let s_connect = s_init.concat_columns(&[&s_init]);
-                s_connect * &bs[0][level_size]
-            };
-            assert_eq!(p_init, expected_p_init);
-            let inserted_poly_gadget = {
-                let zero = <M::P as Poly>::const_zero(&params);
-                let one = <M::P as Poly>::const_one(&params);
-                let mut polys = vec![];
-                polys.push(one);
-                for _ in 0..(packed_input_size - 1) {
-                    polys.push(zero.clone());
-                }
-                polys.push(minus_t_bar.clone());
-                let gadget_d1 = M::gadget_matrix(&params, d1);
-                M::from_poly_vec_row(&params, polys).tensor(&gadget_d1)
-            };
-            let expected_encoding_init = s_init.clone() *
-                &(pub_key_cur[0].concat_matrix(&pub_key_cur[1..]) - inserted_poly_gadget);
-            assert_eq!(encodings[0][0].concat_vector(&encodings[0][1..]), expected_encoding_init);
-        }
-        let nums: Vec<u64> = inputs
-            .chunks(level_width)
-            .map(|chunk| {
-                chunk.iter().enumerate().fold(0u64, |acc, (i, &bit)| acc + ((bit as u64) << i))
-            })
-            .collect();
-        debug_assert_eq!(nums.len(), depth);
-
-        for (level, num) in nums.iter().enumerate() {
-            let m = M::read_from_files(
-                params.as_ref(),
-                m_b,
-                m_b,
-                &dir_path,
-                &format!("m_preimage_{level}_{num}"),
-            );
-            log_mem(format!("m at {} loaded", level));
-            let q = ps[level].clone() * m;
-            log_mem(format!("q at {} computed", level));
-            let n = M::read_from_files(
-                params.as_ref(),
-                m_b,
-                m_b,
-                &dir_path,
-                &format!("n_preimage_{level}_{num}"),
-            );
-            log_mem(format!("n at {} loaded", level));
-            let p = q.clone() * n;
-            log_mem(format!("p at {} computed", level));
-            let k_columns = (1 + packed_input_size) * d1 * log_base_q;
-            let k = M::read_from_files(
-                params.as_ref(),
-                m_b,
-                k_columns,
-                &dir_path,
-                &format!("k_preimage_{level}_{num}"),
-            );
-            log_mem(format!("k at {} loaded", level));
-            let v = q.clone() * k;
-            log_mem(format!("v at {} computed", level));
-            let new_encode_vec = {
-                let rg = &public_data.rgs[*num as usize];
-                let encode_vec = encodings[level][0].concat_vector(&encodings[level][1..]);
-                let packed_input_size = obf_params.input_size.div_ceil(dim) + 1;
-                encode_vec.mul_tensor_identity_decompose(rg, packed_input_size + 1) + v
-            };
-            log_mem(format!("new_encode_vec at {} computed", level));
-            let mut new_encodings = vec![];
-            let inserted_poly_index = 1 + (level * level_width) / dim;
-            let pub_key_level = sample_public_key_by_id(
-                &bgg_pubkey_sampler,
-                &params,
-                level + 1,
-                &reveal_plaintexts,
-            );
-            log_mem(format!("pub_key_level at {} computed", level));
-            for (j, encode) in encodings[level].iter().enumerate() {
-                let m = d1 * log_base_q;
-                let new_vec = new_encode_vec.slice_columns(j * m, (j + 1) * m);
-                log_mem(format!("new_vec at {}, {} computed", level, j));
-                let plaintext = if j == inserted_poly_index {
-                    let inserted_coeff_indices =
-                        (0..level_width).map(|i| (i + (level * level_width)) % dim).collect_vec();
-                    let mut coeffs = encode.plaintext.as_ref().unwrap().coeffs();
-                    let num_bits: Vec<bool> =
-                        (0..level_width).map(|i| (num >> i) & 1 == 1).collect();
-                    debug_assert_eq!(num_bits.len(), level_width);
-                    for (i, coeff_idx) in inserted_coeff_indices.iter().enumerate() {
-                        let bit = num_bits[i];
-                        if bit {
-                            coeffs[*coeff_idx] = <M::P as Poly>::Elem::one(&params.modulus());
-                        }
-                    }
-                    Some(M::P::from_coeffs(&params, &coeffs))
-                } else {
-                    encode.plaintext.clone()
-                };
-                log_mem(format!("plaintext at {}, {} computed", level, j));
-                let new_encode: BggEncoding<M> =
-                    BggEncoding::new(new_vec, pub_key_level[j].clone(), plaintext);
-                log_mem(format!("new_encode at {}, {} computed", level, j));
-                new_encodings.push(new_encode);
+            let mut cur_s = s_init.clone();
+            for prev_num in nums[0..level].iter() {
+                let r = public_data.rs[*prev_num as usize].clone();
+                cur_s = cur_s * r;
             }
-            ps.push(p.clone());
-            pub_key_cur = pub_key_level;
-            encodings.push(new_encodings);
-            #[cfg(feature = "debug")]
-            if obf_params.encoding_sigma == 0.0 &&
-                obf_params.hardcoded_key_sigma == 0.0 &&
-                obf_params.p_sigma == 0.0
-            {
-                let mut cur_s = s_init.clone();
-                for prev_num in nums[0..level].iter() {
-                    let r = public_data.rs[*prev_num as usize].clone();
-                    cur_s = cur_s * r;
-                }
-                let new_s = cur_s.clone() * &public_data.rs[*num as usize];
-                let b_next_bit = bs[level + 1][*num as usize].clone();
-                let expected_q = cur_s.concat_columns(&[&new_s]) * &b_next_bit;
-                assert_eq!(q, expected_q);
-                let expected_p = new_s.concat_columns(&[&new_s]) * &bs[level + 1][level_size];
-                assert_eq!(p, expected_p);
-                let expcted_new_encode = {
-                    let dim = params.ring_dimension() as usize;
-                    let one = <M::P as Poly>::const_one(&params);
-                    let gadget_d1 = M::gadget_matrix(&params, d1);
-                    let inserted_poly_gadget = {
-                        let mut polys = vec![];
-                        polys.push(one);
-                        let mut coeffs = vec![];
-                        for bit in inputs[0..(level_width * (level + 1))].iter() {
-                            if *bit {
-                                coeffs.push(<M::P as Poly>::Elem::one(&params.modulus()));
-                            } else {
-                                coeffs.push(<M::P as Poly>::Elem::zero(&params.modulus()));
-                            }
-                        }
-                        for _ in 0..(obf_params.input_size - level_width * (level + 1)) {
+            let new_s = cur_s.clone() * &public_data.rs[*num as usize];
+            let b_next_bit = bs[level + 1][*num as usize].clone();
+            let expected_q = cur_s.concat_columns(&[&new_s]) * &b_next_bit;
+            assert_eq!(q, expected_q);
+            let expected_p = new_s.concat_columns(&[&new_s]) * &bs[level + 1][level_size];
+            assert_eq!(p, expected_p);
+            let expcted_new_encode = {
+                let dim = params.ring_dimension() as usize;
+                let one = <M::P as Poly>::const_one(&params);
+                let gadget_d1 = M::gadget_matrix(&params, d1);
+                let inserted_poly_gadget = {
+                    let mut polys = vec![];
+                    polys.push(one);
+                    let mut coeffs = vec![];
+                    for bit in inputs[0..(level_width * (level + 1))].iter() {
+                        if *bit {
+                            coeffs.push(<M::P as Poly>::Elem::one(&params.modulus()));
+                        } else {
                             coeffs.push(<M::P as Poly>::Elem::zero(&params.modulus()));
                         }
-                        let input_polys = coeffs
-                            .chunks(dim)
-                            .map(|coeffs| M::P::from_coeffs(&params, coeffs))
-                            .collect_vec();
-                        polys.extend(input_polys);
-                        polys.push(minus_t_bar.clone());
-                        M::from_poly_vec_row(&params, polys).tensor(&gadget_d1)
-                    };
-                    let pubkey = pub_key_cur[0].concat_matrix(&pub_key_cur[1..]);
-                    new_s * (pubkey - inserted_poly_gadget)
+                    }
+                    for _ in 0..(obf_params.input_size - level_width * (level + 1)) {
+                        coeffs.push(<M::P as Poly>::Elem::zero(&params.modulus()));
+                    }
+                    let input_polys = coeffs
+                        .chunks(dim)
+                        .map(|coeffs| M::P::from_coeffs(&params, coeffs))
+                        .collect_vec();
+                    polys.extend(input_polys);
+                    polys.push(minus_t_bar.clone());
+                    M::from_poly_vec_row(&params, polys).tensor(&gadget_d1)
                 };
-                assert_eq!(new_encode_vec, expcted_new_encode);
-            }
+                let pubkey = pub_key_cur[0].concat_matrix(&pub_key_cur[1..]);
+                new_s * (pubkey - inserted_poly_gadget)
+            };
+            assert_eq!(new_encode_vec, expcted_new_encode);
         }
-
-        #[cfg(feature = "bgm")]
-        {
-            player.play_music("bgm/eval_bgm2.mp3");
-        }
-
-        let b = M::read_from_files(&obf_params.params, 1, 1, &dir_path, "b");
-        log_mem("b loaded");
-
-        let a_decomposed = public_data.a_rlwe_bar.entry(0, 0).decompose_base(&params);
-        let b_decomposed = &b.entry(0, 0).decompose_base(&params);
-        log_mem("a,b decomposed");
-        let final_circuit = build_final_digits_circuit::<M::P, BggEncoding<M>>(
-            &a_decomposed,
-            b_decomposed,
-            obf_params.public_circuit,
-        );
-        log_mem("final_circuit built");
-        let last_input_encodings = encodings.last().unwrap();
-        let output_encodings = final_circuit.eval::<BggEncoding<M>>(
-            &params,
-            &last_input_encodings[0],
-            &last_input_encodings[1..],
-        );
-        log_mem("final_circuit evaluated");
-        let output_encoding_ints = output_encodings
-            .par_chunks(log_base_q)
-            .map(|digits| BggEncoding::digits_to_int(digits, &params))
-            .collect::<Vec<_>>();
-        let output_encodings_vec =
-            output_encoding_ints[0].concat_vector(&output_encoding_ints[1..]);
-        log_mem("final_circuit evaluated and recomposed");
-        let final_preimage = M::read_from_files(
-            &obf_params.params,
-            m_b,
-            packed_output_size,
-            &dir_path,
-            "final_preimage",
-        );
-        log_mem("final_preimage loaded");
-        let final_v = ps.last().unwrap().clone() * final_preimage;
-        log_mem("final_v computed");
-        let z = output_encodings_vec - final_v;
-        log_mem("z computed");
-        debug_assert_eq!(z.size(), (1, packed_output_size));
-        #[cfg(feature = "debug")]
-        if obf_params.encoding_sigma == 0.0 &&
-            obf_params.hardcoded_key_sigma == 0.0 &&
-            obf_params.p_sigma == 0.0
-        {
-            let hardcoded_key = <<M as PolyMatrix>::P as Poly>::read_from_file(
-                &obf_params.params,
-                &dir_path,
-                "hardcoded_key",
-            );
-
-            let mut last_s = s_init.clone();
-            for num in nums.iter() {
-                let r = public_data.rs[*num as usize].clone();
-                last_s = last_s * r;
-            }
-            {
-                let expected = last_s *
-                    (output_encoding_ints[0].pubkey.matrix.clone() -
-                        M::unit_column_vector(&params, d1, d1 - 1) *
-                            output_encoding_ints[0].plaintext.clone().unwrap());
-                assert_eq!(output_encoding_ints[0].vector, expected);
-            }
-            assert_eq!(z.size(), (1, packed_output_size));
-            if inputs[0] {
-                assert_eq!(
-                    output_encoding_ints[0]
-                        .plaintext
-                        .clone()
-                        .unwrap()
-                        .extract_bits_with_threshold(&params),
-                    hardcoded_key.to_bool_vec()
-                );
-            }
-        }
-        z.get_row(0).into_iter().flat_map(|p| p.extract_bits_with_threshold(&params)).collect_vec()
     }
+
+    #[cfg(feature = "bgm")]
+    {
+        player.play_music("bgm/eval_bgm2.mp3");
+    }
+
+    let b = M::read_from_files(&obf_params.params, 1, 1, &dir_path, "b");
+    log_mem("b loaded");
+
+    let a_decomposed = public_data.a_rlwe_bar.entry(0, 0).decompose_base(&params);
+    let b_decomposed = &b.entry(0, 0).decompose_base(&params);
+    log_mem("a,b decomposed");
+    let final_circuit = build_final_digits_circuit::<M::P, BggEncoding<M>>(
+        &a_decomposed,
+        b_decomposed,
+        obf_params.public_circuit,
+    );
+    log_mem("final_circuit built");
+    let last_input_encodings = encodings.last().unwrap();
+    let output_encodings = final_circuit.eval::<BggEncoding<M>>(
+        &params,
+        &last_input_encodings[0],
+        &last_input_encodings[1..],
+    );
+    log_mem("final_circuit evaluated");
+    let output_encoding_ints = output_encodings
+        .par_chunks(log_base_q)
+        .map(|digits| BggEncoding::digits_to_int(digits, &params))
+        .collect::<Vec<_>>();
+    let output_encodings_vec = output_encoding_ints[0].concat_vector(&output_encoding_ints[1..]);
+    log_mem("final_circuit evaluated and recomposed");
+    let final_preimage = M::read_from_files(
+        &obf_params.params,
+        m_b,
+        packed_output_size,
+        &dir_path,
+        "final_preimage",
+    );
+    log_mem("final_preimage loaded");
+    let final_v = ps.last().unwrap().clone() * final_preimage;
+    log_mem("final_v computed");
+    let z = output_encodings_vec - final_v;
+    log_mem("z computed");
+    debug_assert_eq!(z.size(), (1, packed_output_size));
+    #[cfg(feature = "debug")]
+    if obf_params.encoding_sigma == 0.0 &&
+        obf_params.hardcoded_key_sigma == 0.0 &&
+        obf_params.p_sigma == 0.0
+    {
+        let hardcoded_key = <<M as PolyMatrix>::P as Poly>::read_from_file(
+            &obf_params.params,
+            &dir_path,
+            "hardcoded_key",
+        );
+
+        let mut last_s = s_init.clone();
+        for num in nums.iter() {
+            let r = public_data.rs[*num as usize].clone();
+            last_s = last_s * r;
+        }
+        {
+            let expected = last_s *
+                (output_encoding_ints[0].pubkey.matrix.clone() -
+                    M::unit_column_vector(&params, d1, d1 - 1) *
+                        output_encoding_ints[0].plaintext.clone().unwrap());
+            assert_eq!(output_encoding_ints[0].vector, expected);
+        }
+        assert_eq!(z.size(), (1, packed_output_size));
+        if inputs[0] {
+            assert_eq!(
+                output_encoding_ints[0]
+                    .plaintext
+                    .clone()
+                    .unwrap()
+                    .extract_bits_with_threshold(&params),
+                hardcoded_key.to_bool_vec()
+            );
+        }
+    }
+    z.get_row(0).into_iter().flat_map(|p| p.extract_bits_with_threshold(&params)).collect_vec()
 }

--- a/src/io/eval.rs
+++ b/src/io/eval.rs
@@ -25,7 +25,7 @@ where
         dir_path: P,
     ) -> Self {
         let dir_path = dir_path.as_ref().to_path_buf();
-        let b = M::read_from_files(&obf_params.params, 1, 1, &dir_path, "b");
+        // let b = M::read_from_files(&obf_params.params, 1, 1, &dir_path, "b");
 
         let dim = obf_params.params.ring_dimension() as usize;
         let packed_input_size = obf_params.input_size.div_ceil(dim) + 1;
@@ -165,7 +165,7 @@ where
             .collect::<Vec<_>>();
 
         Self {
-            b,
+            // b,
             encodings_init,
             // p_init,
             // m_preimages,
@@ -414,8 +414,11 @@ where
             player.play_music("bgm/eval_bgm2.mp3");
         }
 
+        let b = M::read_from_files(&obf_params.params, 1, 1, &dir_path, "b");
+        log_mem("b loaded");
+
         let a_decomposed = public_data.a_rlwe_bar.entry(0, 0).decompose_base(&params);
-        let b_decomposed = &self.b.entry(0, 0).decompose_base(&params);
+        let b_decomposed = &b.entry(0, 0).decompose_base(&params);
         log_mem("a,b decomposed");
         let final_circuit = build_final_digits_circuit::<M::P, BggEncoding<M>>(
             &a_decomposed,

--- a/src/io/eval.rs
+++ b/src/io/eval.rs
@@ -50,11 +50,11 @@ where
             })
             .collect::<Vec<_>>();
 
-        let m_b = (2 * d1) * (2 + log_base_q);
-        // let p_init = M::read_from_files(&obf_params.params, 1, m_b, &dir_path, "p_init");
+        // let m_b = (2 * d1) * (2 + log_base_q);
+        // // let p_init = M::read_from_files(&obf_params.params, 1, m_b, &dir_path, "p_init");
 
-        let level_size = (1u64 << obf_params.level_width) as usize;
-        let depth = obf_params.input_size / obf_params.level_width;
+        // let level_size = (1u64 << obf_params.level_width) as usize;
+        // let depth = obf_params.input_size / obf_params.level_width;
         // let m_preimages = parallel_iter!(0..depth)
         //     .map(|level| {
         //         parallel_iter!(0..level_size)
@@ -101,7 +101,7 @@ where
         //             .collect::<Vec<_>>()
         //     })
         //     .collect::<Vec<_>>();
-        let packed_output_size = obf_params.public_circuit.num_output() / (2 * log_base_q);
+        // let packed_output_size = obf_params.public_circuit.num_output() / (2 * log_base_q);
         // let final_preimage = M::read_from_files(
         //     &obf_params.params,
         //     m_b,
@@ -120,49 +120,49 @@ where
         // #[cfg(feature = "debug")]
         // let s_init = M::read_from_files(&obf_params.params, 1, d1, &dir_path, "s_init");
 
-        #[cfg(feature = "debug")]
-        let minus_t_bar = <<M as PolyMatrix>::P as Poly>::read_from_file(
-            &obf_params.params,
-            &dir_path,
-            "minus_t_bar",
-        );
+        // #[cfg(feature = "debug")]
+        // let minus_t_bar = <<M as PolyMatrix>::P as Poly>::read_from_file(
+        //     &obf_params.params,
+        //     &dir_path,
+        //     "minus_t_bar",
+        // );
 
-        #[cfg(feature = "debug")]
-        let hardcoded_key = <<M as PolyMatrix>::P as Poly>::read_from_file(
-            &obf_params.params,
-            &dir_path,
-            "hardcoded_key",
-        );
+        // #[cfg(feature = "debug")]
+        // let hardcoded_key = <<M as PolyMatrix>::P as Poly>::read_from_file(
+        //     &obf_params.params,
+        //     &dir_path,
+        //     "hardcoded_key",
+        // );
 
-        #[cfg(feature = "debug")]
-        let bs = parallel_iter!(0..depth + 1)
-            .map(|level| {
-                let mut b_nums = if level == 0 {
-                    vec![M::zero(params.as_ref(), 2 * d1, m_b); level_size]
-                } else {
-                    parallel_iter!(0..level_size)
-                        .map(|num| {
-                            M::read_from_files(
-                                params.as_ref(),
-                                2 * d1,
-                                m_b,
-                                &dir_path,
-                                &format!("b_{level}_{num}"),
-                            )
-                        })
-                        .collect::<Vec<_>>()
-                };
-                let b_star = M::read_from_files(
-                    params.as_ref(),
-                    2 * d1,
-                    m_b,
-                    &dir_path,
-                    &format!("b_star_{level}"),
-                );
-                b_nums.push(b_star);
-                b_nums
-            })
-            .collect::<Vec<_>>();
+        // #[cfg(feature = "debug")]
+        // let bs = parallel_iter!(0..depth + 1)
+        //     .map(|level| {
+        //         let mut b_nums = if level == 0 {
+        //             vec![M::zero(params.as_ref(), 2 * d1, m_b); level_size]
+        //         } else {
+        //             parallel_iter!(0..level_size)
+        //                 .map(|num| {
+        //                     M::read_from_files(
+        //                         params.as_ref(),
+        //                         2 * d1,
+        //                         m_b,
+        //                         &dir_path,
+        //                         &format!("b_{level}_{num}"),
+        //                     )
+        //                 })
+        //                 .collect::<Vec<_>>()
+        //         };
+        //         let b_star = M::read_from_files(
+        //             params.as_ref(),
+        //             2 * d1,
+        //             m_b,
+        //             &dir_path,
+        //             &format!("b_star_{level}"),
+        //         );
+        //         b_nums.push(b_star);
+        //         b_nums
+        //     })
+        //     .collect::<Vec<_>>();
 
         Self {
             // b,
@@ -177,8 +177,8 @@ where
             // s_init,
             // #[cfg(feature = "debug")]
             // minus_t_bar,
-            #[cfg(feature = "debug")]
-            bs,
+            // #[cfg(feature = "debug")]
+            // bs,
             // #[cfg(feature = "debug")]
             // hardcoded_key,
         }
@@ -261,13 +261,43 @@ where
         );
 
         #[cfg(feature = "debug")]
+        let bs = parallel_iter!(0..depth + 1)
+            .map(|level| {
+                let mut b_nums = if level == 0 {
+                    vec![M::zero(params.as_ref(), 2 * d1, m_b); level_size]
+                } else {
+                    parallel_iter!(0..level_size)
+                        .map(|num| {
+                            M::read_from_files(
+                                params.as_ref(),
+                                2 * d1,
+                                m_b,
+                                &dir_path,
+                                &format!("b_{level}_{num}"),
+                            )
+                        })
+                        .collect::<Vec<_>>()
+                };
+                let b_star = M::read_from_files(
+                    params.as_ref(),
+                    2 * d1,
+                    m_b,
+                    &dir_path,
+                    &format!("b_star_{level}"),
+                );
+                b_nums.push(b_star);
+                b_nums
+            })
+            .collect::<Vec<_>>();
+
+        #[cfg(feature = "debug")]
         if obf_params.encoding_sigma == 0.0 &&
             obf_params.hardcoded_key_sigma == 0.0 &&
             obf_params.p_sigma == 0.0
         {
             let expected_p_init = {
                 let s_connect = s_init.concat_columns(&[&s_init]);
-                s_connect * &self.bs[0][level_size]
+                s_connect * &bs[0][level_size]
             };
             assert_eq!(p_init, expected_p_init);
             let inserted_poly_gadget = {
@@ -293,6 +323,7 @@ where
             })
             .collect();
         debug_assert_eq!(nums.len(), depth);
+
         for (level, num) in nums.iter().enumerate() {
             let m = M::read_from_files(
                 params.as_ref(),
@@ -382,10 +413,10 @@ where
                     cur_s = cur_s * r;
                 }
                 let new_s = cur_s.clone() * &public_data.rs[*num as usize];
-                let b_next_bit = self.bs[level + 1][*num as usize].clone();
+                let b_next_bit = bs[level + 1][*num as usize].clone();
                 let expected_q = cur_s.concat_columns(&[&new_s]) * &b_next_bit;
                 assert_eq!(q, expected_q);
-                let expected_p = new_s.concat_columns(&[&new_s]) * &self.bs[level + 1][level_size];
+                let expected_p = new_s.concat_columns(&[&new_s]) * &bs[level + 1][level_size];
                 assert_eq!(p, expected_p);
                 let expcted_new_encode = {
                     let dim = params.ring_dimension() as usize;

--- a/src/io/eval.rs
+++ b/src/io/eval.rs
@@ -90,10 +90,10 @@ where
     assert!(inputs.len() % level_width == 0);
     let depth = obf_params.input_size / level_width;
 
-    #[cfg(feature = "debug")]
-    let reveal_plaintexts = [vec![true; packed_input_size - 1], vec![true; 1]].concat();
-    #[cfg(not(feature = "debug"))]
-    let reveal_plaintexts = [vec![true; packed_input_size - 1], vec![false; 1]].concat();
+    // drop the first element from `reveal_plaintexts`` (this is set to true for `one` encofing
+    // within the sample logic)
+    let reveal_plaintexts = reveal_plaintexts[1..].to_vec();
+
     let pub_key_init = sample_public_key_by_id(&bgg_pubkey_sampler, &params, 0, &reveal_plaintexts);
     log_mem("Sampled pub_key_init");
 

--- a/src/io/eval.rs
+++ b/src/io/eval.rs
@@ -51,56 +51,56 @@ where
             .collect::<Vec<_>>();
 
         let m_b = (2 * d1) * (2 + log_base_q);
-        let p_init = M::read_from_files(&obf_params.params, 1, m_b, &dir_path, "p_init");
+        // let p_init = M::read_from_files(&obf_params.params, 1, m_b, &dir_path, "p_init");
 
         let level_size = (1u64 << obf_params.level_width) as usize;
         let depth = obf_params.input_size / obf_params.level_width;
-        let m_preimages = parallel_iter!(0..depth)
-            .map(|level| {
-                parallel_iter!(0..level_size)
-                    .map(|num| {
-                        M::read_from_files(
-                            params.as_ref(),
-                            m_b,
-                            m_b,
-                            &dir_path,
-                            &format!("m_preimage_{level}_{num}"),
-                        )
-                    })
-                    .collect::<Vec<_>>()
-            })
-            .collect::<Vec<_>>();
-        let n_preimages = parallel_iter!(0..depth)
-            .map(|level| {
-                parallel_iter!(0..level_size)
-                    .map(|num| {
-                        M::read_from_files(
-                            params.as_ref(),
-                            m_b,
-                            m_b,
-                            &dir_path,
-                            &format!("n_preimage_{level}_{num}"),
-                        )
-                    })
-                    .collect::<Vec<_>>()
-            })
-            .collect::<Vec<_>>();
-        let k_columns = (1 + packed_input_size) * d1 * log_base_q;
-        let k_preimages = parallel_iter!(0..depth)
-            .map(|level| {
-                parallel_iter!(0..level_size)
-                    .map(|num| {
-                        M::read_from_files(
-                            params.as_ref(),
-                            m_b,
-                            k_columns,
-                            &dir_path,
-                            &format!("k_preimage_{level}_{num}"),
-                        )
-                    })
-                    .collect::<Vec<_>>()
-            })
-            .collect::<Vec<_>>();
+        // let m_preimages = parallel_iter!(0..depth)
+        //     .map(|level| {
+        //         parallel_iter!(0..level_size)
+        //             .map(|num| {
+        //                 M::read_from_files(
+        //                     params.as_ref(),
+        //                     m_b,
+        //                     m_b,
+        //                     &dir_path,
+        //                     &format!("m_preimage_{level}_{num}"),
+        //                 )
+        //             })
+        //             .collect::<Vec<_>>()
+        //     })
+        //     .collect::<Vec<_>>();
+        // let n_preimages = parallel_iter!(0..depth)
+        //     .map(|level| {
+        //         parallel_iter!(0..level_size)
+        //             .map(|num| {
+        //                 M::read_from_files(
+        //                     params.as_ref(),
+        //                     m_b,
+        //                     m_b,
+        //                     &dir_path,
+        //                     &format!("n_preimage_{level}_{num}"),
+        //                 )
+        //             })
+        //             .collect::<Vec<_>>()
+        //     })
+        //     .collect::<Vec<_>>();
+        // let k_columns = (1 + packed_input_size) * d1 * log_base_q;
+        // let k_preimages = parallel_iter!(0..depth)
+        //     .map(|level| {
+        //         parallel_iter!(0..level_size)
+        //             .map(|num| {
+        //                 M::read_from_files(
+        //                     params.as_ref(),
+        //                     m_b,
+        //                     k_columns,
+        //                     &dir_path,
+        //                     &format!("k_preimage_{level}_{num}"),
+        //                 )
+        //             })
+        //             .collect::<Vec<_>>()
+        //     })
+        //     .collect::<Vec<_>>();
         let packed_output_size = obf_params.public_circuit.num_output() / (2 * log_base_q);
         let final_preimage = M::read_from_files(
             &obf_params.params,
@@ -167,7 +167,7 @@ where
         Self {
             b,
             encodings_init,
-            p_init,
+            // p_init,
             // m_preimages,
             // n_preimages,
             // k_preimages,
@@ -218,7 +218,9 @@ where
         let packed_input_size = public_data.packed_input_size;
         let packed_output_size = public_data.packed_output_size;
         let (mut ps, mut encodings) = (vec![], vec![]);
-        ps.push(self.p_init.clone());
+        let p_init = M::read_from_files(&obf_params.params, 1, m_b, &dir_path, "p_init");
+        log_mem("p_init loaded");
+        ps.push(p_init.clone());
         encodings.push(self.encodings_init.clone());
 
         let level_width = obf_params.level_width;
@@ -246,7 +248,7 @@ where
                 let s_connect = self.s_init.concat_columns(&[&self.s_init]);
                 s_connect * &self.bs[0][level_size]
             };
-            assert_eq!(self.p_init, expected_p_init);
+            assert_eq!(p_init, expected_p_init);
             let inserted_poly_gadget = {
                 let zero = <M::P as Poly>::const_zero(&params);
                 let one = <M::P as Poly>::const_one(&params);

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -12,7 +12,7 @@ pub mod utils;
 #[derive(Debug, Clone)]
 pub struct Obfuscation<M: PolyMatrix> {
     // pub hash_key: [u8; 32],
-    pub b: M,
+    // pub b: M,
     pub encodings_init: Vec<BggEncoding<M>>,
     // pub p_init: M,
     // pub m_preimages: Vec<Vec<M>>,

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -14,7 +14,7 @@ pub struct Obfuscation<M: PolyMatrix> {
     pub hash_key: [u8; 32],
     pub b: M,
     pub encodings_init: Vec<BggEncoding<M>>,
-    pub p_init: M,
+    // pub p_init: M,
     // pub m_preimages: Vec<Vec<M>>,
     // pub n_preimages: Vec<Vec<M>>,
     // pub k_preimages: Vec<Vec<M>>,

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -19,12 +19,12 @@ pub struct Obfuscation<M: PolyMatrix> {
     // pub n_preimages: Vec<Vec<M>>,
     // pub k_preimages: Vec<Vec<M>>,
     // pub final_preimage: M,
-    #[cfg(feature = "debug")]
-    pub s_init: M,
-    #[cfg(feature = "debug")]
-    pub minus_t_bar: <M as PolyMatrix>::P,
+    // #[cfg(feature = "debug")]
+    // pub s_init: M,
+    // #[cfg(feature = "debug")]
+    // pub minus_t_bar: <M as PolyMatrix>::P,
     #[cfg(feature = "debug")]
     pub bs: Vec<Vec<M>>,
-    #[cfg(feature = "debug")]
-    pub hardcoded_key: <M as PolyMatrix>::P,
+    // #[cfg(feature = "debug")]
+    // pub hardcoded_key: <M as PolyMatrix>::P,
 }

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -15,9 +15,9 @@ pub struct Obfuscation<M: PolyMatrix> {
     pub b: M,
     pub encodings_init: Vec<BggEncoding<M>>,
     pub p_init: M,
-    pub m_preimages: Vec<Vec<M>>,
-    pub n_preimages: Vec<Vec<M>>,
-    pub k_preimages: Vec<Vec<M>>,
+    // pub m_preimages: Vec<Vec<M>>,
+    // pub n_preimages: Vec<Vec<M>>,
+    // pub k_preimages: Vec<Vec<M>>,
     pub final_preimage: M,
     #[cfg(feature = "debug")]
     pub s_init: M,

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -11,14 +11,14 @@ pub mod utils;
 
 #[derive(Debug, Clone)]
 pub struct Obfuscation<M: PolyMatrix> {
-    pub hash_key: [u8; 32],
+    // pub hash_key: [u8; 32],
     pub b: M,
     pub encodings_init: Vec<BggEncoding<M>>,
     // pub p_init: M,
     // pub m_preimages: Vec<Vec<M>>,
     // pub n_preimages: Vec<Vec<M>>,
     // pub k_preimages: Vec<Vec<M>>,
-    pub final_preimage: M,
+    // pub final_preimage: M,
     #[cfg(feature = "debug")]
     pub s_init: M,
     #[cfg(feature = "debug")]

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -1,30 +1,8 @@
 #[cfg(feature = "bgm")]
 pub mod bgm;
 
-use crate::{bgg::BggEncoding, poly::PolyMatrix};
-
 pub mod eval;
 pub mod obf;
 pub mod params;
 pub mod serde;
 pub mod utils;
-
-#[derive(Debug, Clone)]
-pub struct Obfuscation<M: PolyMatrix> {
-    // pub hash_key: [u8; 32],
-    // pub b: M,
-    pub encodings_init: Vec<BggEncoding<M>>,
-    // pub p_init: M,
-    // pub m_preimages: Vec<Vec<M>>,
-    // pub n_preimages: Vec<Vec<M>>,
-    // pub k_preimages: Vec<Vec<M>>,
-    // pub final_preimage: M,
-    // #[cfg(feature = "debug")]
-    // pub s_init: M,
-    // #[cfg(feature = "debug")]
-    // pub minus_t_bar: <M as PolyMatrix>::P,
-    // #[cfg(feature = "debug")]
-    // pub bs: Vec<Vec<M>>,
-    // #[cfg(feature = "debug")]
-    // pub hardcoded_key: <M as PolyMatrix>::P,
-}

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -23,8 +23,8 @@ pub struct Obfuscation<M: PolyMatrix> {
     // pub s_init: M,
     // #[cfg(feature = "debug")]
     // pub minus_t_bar: <M as PolyMatrix>::P,
-    #[cfg(feature = "debug")]
-    pub bs: Vec<Vec<M>>,
+    // #[cfg(feature = "debug")]
+    // pub bs: Vec<Vec<M>>,
     // #[cfg(feature = "debug")]
     // pub hardcoded_key: <M as PolyMatrix>::P,
 }

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -2,7 +2,7 @@
 use crate::utils::calculate_tmp_size;
 use crate::{
     bgg::circuit::PolyCircuit,
-    io::{obf::obfuscate, params::ObfuscationParams, Obfuscation},
+    io::{eval::evaluate, obf::obfuscate, params::ObfuscationParams},
     poly::{
         dcrt::{
             DCRTPoly, DCRTPolyHashSampler, DCRTPolyMatrix, DCRTPolyParams, DCRTPolyTrapdoorSampler,
@@ -100,27 +100,15 @@ pub async fn test_io_common(
     let bool_in = rng.random::<bool>();
     let mut input = vec![bool_in];
     input.append(&mut vec![false; input_size - 1]);
-    // #[cfg(feature = "disk")]
-    // clean_tmp().unwrap();
-    #[cfg(feature = "disk")]
-    let tmp_start_size = calculate_tmp_size();
-    let start_time = std::time::Instant::now();
-    let obfuscation = Obfuscation::read_dir(&obf_params, dir_path);
-    let load_time = start_time.elapsed();
-    info!("Time to load obfuscation: {:?}", load_time);
-    #[cfg(feature = "disk")]
-    let tmp_end_size = calculate_tmp_size();
-    #[cfg(feature = "disk")]
-    log_mem(format!("Obfuscation size after loading: {} bytes", tmp_end_size - tmp_start_size));
 
     let start_time = std::time::Instant::now();
-    let output = obfuscation
-        .evaluate::<DCRTPolyHashSampler<Keccak256>, DCRTPolyTrapdoorSampler, _>(
+    let output =
+        evaluate::<DCRTPolyMatrix, DCRTPolyHashSampler<Keccak256>, DCRTPolyTrapdoorSampler, _>(
             obf_params, &input, &dir_path,
         );
     let eval_time = start_time.elapsed();
     info!("Time for evaluation: {:?}", eval_time);
-    info!("Total time: {:?}", obfuscation_time + load_time + eval_time);
+    info!("Total time: {:?}", obfuscation_time + eval_time);
 
     let input_poly =
         DCRTPoly::from_const(&params, &FinRingElem::constant(&params.modulus(), bool_in as u64));

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -115,7 +115,9 @@ pub async fn test_io_common(
 
     let start_time = std::time::Instant::now();
     let output = obfuscation
-        .eval::<DCRTPolyHashSampler<Keccak256>, DCRTPolyTrapdoorSampler>(obf_params, &input);
+        .evaluate::<DCRTPolyHashSampler<Keccak256>, DCRTPolyTrapdoorSampler, _>(
+            obf_params, &input, &dir_path,
+        );
     let eval_time = start_time.elapsed();
     info!("Time for evaluation: {:?}", eval_time);
     info!("Total time: {:?}", obfuscation_time + load_time + eval_time);


### PR DESCRIPTION
The obfuscation artifacts are no longer loaded all at once during evaluation phase but dynamically when needed. Furthermore, for the `m, n, k` preimages, we are only loading the one related to the `num` input chosen by the evaluator. 