### PR TITLE
ci: benchmark workflow 

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -67,7 +67,6 @@ jobs:
       - name: Verify OpenFHE install
         run: ls -lah /usr/local/lib | grep OpenFHE
 
-      # ───────────────────────────────────────────────────────────────────────────
       - name: Install dio
         run: cargo install --path dio
 
@@ -90,8 +89,31 @@ jobs:
           echo "Benchmark PID: $pid"
           wait $pid
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Install the project
+        run: uv sync --locked --all-extras --dev
+
       - name: Upload benchmark logs
         uses: actions/upload-artifact@v4
         with:
           name: bench-logs
           path: logs/*.log
+
+      - name: Run memory profiling
+        run: |
+          LOG=logs/data_${{ github.event.inputs.data_id }}_param_${{ github.event.inputs.param_id }}.log
+          uv run memory_profile.py --log-file "$LOG"
+
+      - name: Upload memory analysis
+        uses: actions/upload-artifact@v4
+        with:
+          name: memory-analysis
+          path: logs/combined_memory_analysis_*.txt
+
+      - name: Clean up logs
+        if: always()
+        run: rm -rf logs
+
+

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -48,13 +48,24 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y build-essential cmake libgmp-dev libasound2-dev
 
+      - name: Check for OpenFHE
+        id: openfhe-check
+        run: |
+          if ldconfig -p | grep -q 'libOpenFHE'; then
+            echo "installed=true" >> $GITHUB_OUTPUT
+          else
+            echo "installed=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Checkout OpenFHE
+        if: steps.openfhe-check.outputs.installed == 'false'
         uses: actions/checkout@v4
         with:
           repository: openfheorg/openfhe-development
           path: openfhe
 
       - name: Build & install OpenFHE
+        if: steps.openfhe-check.outputs.installed == 'false'
         run: |
           cd openfhe
           mkdir -p build && cd build


### PR DESCRIPTION
finalizing benchmark workflow until feature of combining custom runner.
this ci checks openfhe installation, if not install, 
install latest `dio` binary and run bench base on provided input on CI.
After it upload log and memory analyzed file to github 