### PR TITLE
fix: rm encoding sigma

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Our simulator only targets circuits used for our benchmarks.
 4. Run `sage main.py` under the `simulator` directory.
 
 If the script is completed without any error, the found parameters are added to the last line in `simulator/params.log`. 
-Among the parameters, `crt_depth` denotes the minimum number of moduli satisfying correctness and security, and `d`, `encoding_sigma`, `hardcoded_key_sigma`, `p_sigma`, and `switched_modulus` can be used for `ObfuscationParams`.
+Among the parameters, `crt_depth` denotes the minimum number of moduli satisfying correctness and security, and `d`, `hardcoded_key_sigma`, `p_sigma`, and `switched_modulus` can be used for `ObfuscationParams`.
 
 
 ## Acknowledgments

--- a/dio/src/config.rs
+++ b/dio/src/config.rs
@@ -29,7 +29,6 @@ pub struct RunBenchConfig {
     pub input_size: usize,
     pub level_width: usize,
     pub d: usize,
-    pub encoding_sigma: f64,
     pub hardcoded_key_sigma: f64,
     pub p_sigma: f64,
     #[serde(default = "default_trapdoor_sigma")]

--- a/e2e/dio-config.dummy.toml
+++ b/e2e/dio-config.dummy.toml
@@ -6,7 +6,6 @@ switched_modulus = "1"
 d = 3
 input_size = 4
 level_width = 1
-encoding_sigma = 0.0
 hardcoded_key_sigma = 0.0
 p_sigma = 0.0
 input = [true, false, false, false]

--- a/src/io/serde.rs
+++ b/src/io/serde.rs
@@ -26,7 +26,6 @@ pub struct SerializableObfuscationParams {
     pub level_width: usize,
     pub public_circuit_path: PathBuf,
     pub d: usize,
-    pub encoding_sigma: f64,
     pub hardcoded_key_sigma: f64,
     pub p_sigma: f64,
     pub trapdoor_sigma: f64,


### PR DESCRIPTION
fix dio config as we no need encoding sigma
check with https://github.com/MachinaIO/diamond-io/actions/runs/14901775460 ci