### PR TITLE
fix: The job has exceeded the maximum execution time

### DIFF
--- a/.github/workflows/benchmark-self-hosted.yml
+++ b/.github/workflows/benchmark-self-hosted.yml
@@ -58,6 +58,7 @@ jobs:
   bench:
     needs: launch-ec2
     runs-on: ["${{github.run_id}}", self-hosted]
+    timeout-minutes: 5760 #4days
     strategy:
       fail-fast: false
 


### PR DESCRIPTION
The default job execution time is 6 hours.
For self-hosted runners we can configure a higher timeout-minutes value.

The execution timeout threshold was set to 4days