### PR TITLE
fix add `t_num`

### DIFF
--- a/dio/src/main.rs
+++ b/dio/src/main.rs
@@ -95,6 +95,9 @@ enum Commands {
 
         #[arg(long, requires_if("add_mul", "bench_type"))]
         mul_num: Option<usize>,
+
+        #[arg(long, requires_if("plt", "bench_type"))]
+        t_num: Option<usize>,
     },
     BuildCircuit {
         #[arg(short, long)]
@@ -237,7 +240,7 @@ async fn main() {
                 }
             }
         }
-        Commands::SimBenchNorm { config, out_path, add_num, mul_num, bench_type } => {
+        Commands::SimBenchNorm { config, out_path, add_num, mul_num, t_num, bench_type } => {
             let dio_config: SimBenchNormConfig =
                 serde_json::from_reader(fs::File::open(&config).unwrap()).unwrap();
             let log_n = dio_config.log_ring_dim;
@@ -257,8 +260,8 @@ async fn main() {
                     BenchCircuit::new_add_mul(add_num, mul_num, log_base_q).as_poly_circuit()
                 }
                 BenchType::Plt => {
-                    // To simulate the norm, value T(=table row size) is not relevant
-                    let plt = setup_lsb_plt(0, &params, dio_config.d);
+                    let t_num = t_num.unwrap();
+                    let plt = setup_lsb_plt(t_num, &params, dio_config.d);
                     BenchCircuit::new_plt(log_base_q, plt.clone()).as_poly_circuit()
                 }
             };

--- a/simulator/main.py
+++ b/simulator/main.py
@@ -131,7 +131,7 @@ def find_params(
             if bench_type == "add_mul":
                 cmd += ["--add-num", str(add_num), "--mul-num", str(mul_num)]
             elif bench_type == "plt":
-                cmd += ["--t_num", str(t_num)]
+                cmd += ["--t-num", str(t_num)]
             else:
                 raise ValueError(f"Unsupported bench_type: {bench_type}")
             subprocess.run(cmd, check=True)

--- a/simulator/main.py
+++ b/simulator/main.py
@@ -22,6 +22,7 @@ def log_params_to_file(
     input_width: int,
     add_num: int,
     mul_num: int,
+    t_num: int,
     max_crt_depth: int,
     secpar: int,
     n: int,
@@ -56,6 +57,7 @@ def log_params_to_file(
         f"input_width={input_width}, "
         f"add_num={add_num}, "
         f"mul_num={mul_num}, "
+        f"t_num={t_num}, "
         f"max_crt_depth={max_crt_depth}, "
         f"secpar={secpar}, "
         f"n={n}, "
@@ -92,6 +94,7 @@ def find_params(
     bench_type: str,
     add_num: int,
     mul_num: int,
+    t_num: int,
 ):
     for d in range(1, max_d + 1):
         print(f"Trying d: {d}")
@@ -105,7 +108,7 @@ def find_params(
                 "crt_bits": crt_bits,
                 "base_bits": base_bits,
             }
-            config_file = f"sim_norm_config_{input_size}_{input_width}_{bench_type}_{add_num}_{mul_num}_{log2_n}_{max_crt_depth}_{crt_bits}_{base_bits}.json"
+            config_file = f"sim_norm_config_{input_size}_{input_width}_{bench_type}_{add_num}_{mul_num}_{t_num}_{log2_n}_{max_crt_depth}_{crt_bits}_{base_bits}.json"
             with open(
                 os.path.join(
                     script_dir,
@@ -116,7 +119,7 @@ def find_params(
                 f.write(json.dumps(config, indent=4))
             norms_path = os.path.join(
                 script_dir,
-                f"norms_{input_size}_{input_width}_{bench_type}_{add_num}_{mul_num}_{log2_n}_{max_crt_depth}_{crt_bits}_{base_bits}.json",
+                f"norms_{input_size}_{input_width}_{bench_type}_{add_num}_{mul_num}_{t_num}_{log2_n}_{max_crt_depth}_{crt_bits}_{base_bits}.json",
             )
             cmd = [
                 "dio",
@@ -128,7 +131,7 @@ def find_params(
             if bench_type == "add_mul":
                 cmd += ["--add-num", str(add_num), "--mul-num", str(mul_num)]
             elif bench_type == "plt":
-                cmd
+                cmd += ["--t_num", str(t_num)]
             else:
                 raise ValueError(f"Unsupported bench_type: {bench_type}")
             subprocess.run(cmd, check=True)
@@ -601,6 +604,7 @@ if __name__ == "__main__":
     bench_type = "plt"
     add_num = 0
     mul_num = 0
+    t_num = 8
     if input_size % input_width != 0:
         raise ValueError("input_size should be divisible by input_width")
     (
@@ -625,6 +629,7 @@ if __name__ == "__main__":
         bench_type,
         add_num,
         mul_num,
+        t_num,
     )
     print(f"input_size: {input_size}")
     print(f"input_width: {input_width}")
@@ -644,6 +649,7 @@ if __name__ == "__main__":
         input_width,
         add_num,
         mul_num,
+        t_num,
         max_crt_depth,
         secpar,
         2**log2_n,

--- a/src/bgg/lut/public_lut.rs
+++ b/src/bgg/lut/public_lut.rs
@@ -70,15 +70,13 @@ impl<M: PolyMatrix> PublicLut<M> {
 
     /// Find the row k with the maximum coefficient in the second M::P (y_k) of f HashMap
     /// Returns (k, max_coefficient)
-    pub fn max_output_row(&self) -> Option<(usize, <M::P as Poly>::Elem)> {
+    pub fn max_output_row(&self) -> (usize, <M::P as Poly>::Elem) {
+        assert!(!self.f.is_empty(), "f must contain at least one element");
         self.f
             .iter()
-            .map(|(&k, (_, y_k))| {
-                let max_coeff = y_k.coeffs().iter().max().cloned();
-                (k, max_coeff)
-            })
-            .filter_map(|(k, max_coeff)| max_coeff.map(|coeff| (k, coeff)))
-            .max_by_key(|(_, coeff)| coeff.clone())
+            .filter_map(|(&k, (_, y_k))| y_k.coeffs().iter().max().cloned().map(|coeff| (k, coeff)))
+            .max_by(|a, b| a.1.cmp(&b.1))
+            .expect("no coefficients found in any y_k")
     }
 
     /// Compute target, sample preimage and store it as file.

--- a/src/bgg/norm_simulator.rs
+++ b/src/bgg/norm_simulator.rs
@@ -126,7 +126,7 @@ impl Evaluable for NormSimulator {
             // |c_z · r_k.decompose()| + c_lt_k
             h_norm: self.h_norm.right_rotate(self.dim_sqrt as u64 * (self.base as u64 - 1)) +
                 MPolyCoeffs::one(),
-            plaintext_norm: plt.max_output_row().unwrap().1.value().clone(),
+            plaintext_norm: plt.max_output_row().1.value().clone(),
             dim_sqrt: self.dim_sqrt,
             base: self.base,
         }

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -232,9 +232,8 @@ fn setup_lsb_constant_binary_plt(
 
 pub fn setup_lsb_plt(t_n: usize, params: &DCRTPolyParams, d: usize) -> PublicLut<DCRTPolyMatrix> {
     let mut f = HashMap::new();
-    let mut rng = rng();
     for k in 0..t_n {
-        let r_val: usize = rng.random_range(0..t_n as usize);
+        let r_val: usize = t_n - k;
         f.insert(
             k,
             (


### PR DESCRIPTION
due to `max_output_row` introduced in #146 , we need to backup `t_num` for simulate bench so to initiate deterministic public lookup table.