### PR TITLE
fix: overflow while conversion

### DIFF
--- a/dio/src/main.rs
+++ b/dio/src/main.rs
@@ -230,8 +230,9 @@ async fn main() {
                 */
                 let half_q = FinRingElem::half_q(&obf_params.params.modulus());
                 for e in eval {
-                    let expected_output = (DCRTPoly::from_const(&obf_params.params, &half_q) * e)
-                        .extract_bits_with_threshold(&obf_params.params);
+                    let expected_output =
+                        (DCRTPoly::from_elem_to_constant(&obf_params.params, &half_q) * e)
+                            .extract_bits_with_threshold(&obf_params.params);
                     assert_eq!(output, expected_output);
                 }
             }

--- a/src/bgg/circuit/mod.rs
+++ b/src/bgg/circuit/mod.rs
@@ -467,7 +467,7 @@ mod tests {
         poly::{
             dcrt::{
                 params::DCRTPolyParams, poly::DCRTPoly, sampler::uniform::DCRTPolyUniformSampler,
-                DCRTPolyMatrix, FinRingElem,
+                DCRTPolyMatrix,
             },
             enc::rlwe_encrypt,
             sampler::{DistType, PolyUniformSampler},
@@ -884,9 +884,7 @@ mod tests {
             None::<PolyPltEvaluator>,
         );
         let expected = (poly1.clone() + poly2.clone()) -
-            (DCRTPoly::from_const(&params, &FinRingElem::new(2, params.modulus())) *
-                poly1 *
-                poly2);
+            (DCRTPoly::from_usize_to_constant(&params, 2) * poly1 * poly2);
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].coeffs(), expected.coeffs());
     }
@@ -908,9 +906,7 @@ mod tests {
         );
         let expected = DCRTPoly::const_one(&params) -
             ((poly1.clone() + poly2.clone()) -
-                (DCRTPoly::from_const(&params, &FinRingElem::new(2, params.modulus())) *
-                    poly1 *
-                    poly2));
+                (DCRTPoly::from_usize_to_constant(&params, 2) * poly1 * poly2));
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].coeffs(), expected.coeffs());
     }

--- a/src/bgg/digits_to_int.rs
+++ b/src/bgg/digits_to_int.rs
@@ -60,14 +60,12 @@ mod tests {
         },
         poly::{
             dcrt::{
-                element::FinRingElem,
                 matrix::DCRTPolyMatrix,
                 params::DCRTPolyParams,
                 poly::DCRTPoly,
                 sampler::{hash::DCRTPolyHashSampler, uniform::DCRTPolyUniformSampler},
             },
             sampler::PolyUniformSampler,
-            PolyElem,
         },
         utils::{create_bit_random_poly, create_random_poly},
     };
@@ -94,16 +92,14 @@ mod tests {
         let params = DCRTPolyParams::default();
 
         // Create digit polynomials with known values
-        let digit_polys =
-            DCRTPoly::from_const(&params, &FinRingElem::constant(&params.modulus(), 13))
-                .decompose_base(&params);
+        let digit_polys = DCRTPoly::from_usize_to_constant(&params, 13).decompose_base(&params);
 
         // Compute the integer representation
         let result = DCRTPoly::digits_to_int(&digit_polys, &params);
 
         // Expected result: 1 + 2 + 0 + 8 = 11
         // In polynomial form, this is a constant polynomial with value 11
-        let expected = DCRTPoly::from_const(&params, &FinRingElem::new(13u32, params.modulus()));
+        let expected = DCRTPoly::from_usize_to_constant(&params, 13);
         assert_eq!(result, expected, "digits_to_int result does not match expected value 13");
     }
 
@@ -170,7 +166,7 @@ mod tests {
 
         // Create secret and plaintexts (digit polynomials)
         let secrets = vec![create_bit_random_poly(&params); d];
-        let int_poly = DCRTPoly::from_const(&params, &FinRingElem::constant(&params.modulus(), 13));
+        let int_poly = DCRTPoly::from_usize_to_constant(&params, 13);
         let plaintexts = int_poly.decompose_base(&params);
 
         // Create encoding sampler and encodings

--- a/src/bgg/digits_to_int.rs
+++ b/src/bgg/digits_to_int.rs
@@ -18,14 +18,14 @@ pub trait DigitsToInt<P: Poly>: Evaluable {
 
 impl<P: Poly> DigitsToInt<P> for P {
     fn power_of_base(&self, params: &P::Params, k: usize) -> Self {
-        let power_of_base = P::const_power_of_base(params, k);
+        let power_of_base = P::from_power_of_base_to_constant(params, k);
         self.clone() * power_of_base
     }
 }
 
 impl<M: PolyMatrix> DigitsToInt<M::P> for BggPublicKey<M> {
     fn power_of_base(&self, params: &<M::P as crate::poly::Poly>::Params, k: usize) -> Self {
-        let scalar = M::P::const_power_of_base(params, k);
+        let scalar = M::P::from_power_of_base_to_constant(params, k);
         // d+1
         let d1 = self.matrix.row_size();
         let unit_vector = M::unit_column_vector(params, d1, d1 - 1);
@@ -38,7 +38,7 @@ impl<M: PolyMatrix> DigitsToInt<M::P> for BggPublicKey<M> {
 
 impl<M: PolyMatrix> DigitsToInt<M::P> for BggEncoding<M> {
     fn power_of_base(&self, params: &<M::P as crate::poly::Poly>::Params, k: usize) -> Self {
-        let scalar = M::P::const_power_of_base(params, k);
+        let scalar = M::P::from_power_of_base_to_constant(params, k);
         // d+1
         let d1 = self.pubkey.matrix.row_size();
         let unit_vector = M::unit_column_vector(params, d1, d1 - 1);

--- a/src/bgg/encoding.rs
+++ b/src/bgg/encoding.rs
@@ -695,7 +695,7 @@ mod tests {
 
         // Create secret and plaintexts
         let k = 2;
-        let plaintexts = vec![DCRTPoly::const_int(&params, k)];
+        let plaintexts = vec![DCRTPoly::from_usize_to_constant(&params, k)];
 
         // Create encoding sampler and encodings
         let bgg_encoding_sampler = BGGEncodingSampler::new(&params, &secrets, uniform_sampler, 0.0);

--- a/src/poly/dcrt/matrix/dcrt_poly.rs
+++ b/src/poly/dcrt/matrix/dcrt_poly.rs
@@ -389,11 +389,10 @@ mod tests {
 
         // Create a simple 2x8 matrix with some non-zero values
         let mut matrix_vec = Vec::with_capacity(2);
-        let value = FinRingElem::new(5u32, params.modulus());
-
+        let value = 5;
         // Create first row
         let mut row1 = Vec::with_capacity(8);
-        row1.push(DCRTPoly::from_const(&params, &value));
+        row1.push(DCRTPoly::from_usize_to_constant(&params, value));
         for _ in 1..8 {
             row1.push(DCRTPoly::const_zero(&params));
         }
@@ -401,7 +400,7 @@ mod tests {
         // Create second row
         let mut row2 = Vec::with_capacity(8);
         row2.push(DCRTPoly::const_zero(&params));
-        row2.push(DCRTPoly::from_const(&params, &value));
+        row2.push(DCRTPoly::from_usize_to_constant(&params, value));
         for _ in 2..8 {
             row2.push(DCRTPoly::const_zero(&params));
         }
@@ -434,11 +433,11 @@ mod tests {
 
         // Create a simple 2x8 matrix with some non-zero values
         let mut matrix_vec = Vec::with_capacity(2);
-        let value = FinRingElem::new(5u32, params.modulus());
+        let value = 5;
 
         // Create first row
         let mut row1 = Vec::with_capacity(8);
-        row1.push(DCRTPoly::from_const(&params, &value));
+        row1.push(DCRTPoly::from_usize_to_constant(&params, value));
         for _ in 1..8 {
             row1.push(DCRTPoly::const_zero(&params));
         }
@@ -446,7 +445,7 @@ mod tests {
         // Create second row
         let mut row2 = Vec::with_capacity(8);
         row2.push(DCRTPoly::const_zero(&params));
-        row2.push(DCRTPoly::from_const(&params, &value));
+        row2.push(DCRTPoly::from_usize_to_constant(&params, value));
         for _ in 2..8 {
             row2.push(DCRTPoly::const_zero(&params));
         }
@@ -481,16 +480,16 @@ mod tests {
         let identity = DCRTPolyMatrix::identity(&params, 2, None);
 
         // Test matrix creation and equality
-        let value = FinRingElem::new(5u32, params.modulus());
+        let value = 5;
 
         // Create a 2x2 matrix with values at (0,0) and (1,1)
         let matrix_vec = vec![
-            vec![DCRTPoly::from_const(&params, &value), DCRTPoly::const_zero(&params)],
-            vec![DCRTPoly::const_zero(&params), DCRTPoly::from_const(&params, &value)],
+            vec![DCRTPoly::from_usize_to_constant(&params, value), DCRTPoly::const_zero(&params)],
+            vec![DCRTPoly::const_zero(&params), DCRTPoly::from_usize_to_constant(&params, value)],
         ];
 
         let matrix1 = DCRTPolyMatrix::from_poly_vec(&params, matrix_vec);
-        assert_eq!(matrix1.entry(0, 0).coeffs()[0], value);
+        assert_eq!(matrix1.entry(0, 0).coeffs()[0].value(), &BigUint::from(value));
         let matrix2 = matrix1.clone();
         assert_eq!(matrix1, matrix2);
 
@@ -507,8 +506,8 @@ mod tests {
         let prod = matrix1 * &identity;
         assert_eq!(prod.size(), (2, 2));
         // Check that the product has the same values as the original matrix
-        assert_eq!(prod.entry(0, 0).coeffs()[0], value);
-        assert_eq!(prod.entry(1, 1).coeffs()[0], value);
+        assert_eq!(prod.entry(0, 0).coeffs()[0].value(), &BigUint::from(value));
+        assert_eq!(prod.entry(1, 1).coeffs()[0].value(), &BigUint::from(value));
     }
 
     #[test]
@@ -518,7 +517,7 @@ mod tests {
 
         // Create first matrix with value at (0,0)
         let matrix1_vec = vec![
-            vec![DCRTPoly::from_const(&params, &value), DCRTPoly::const_zero(&params)],
+            vec![DCRTPoly::from_elem_to_constant(&params, &value), DCRTPoly::const_zero(&params)],
             vec![DCRTPoly::const_zero(&params), DCRTPoly::const_zero(&params)],
         ];
 
@@ -527,7 +526,7 @@ mod tests {
         // Create second matrix with value at (1,1)
         let matrix2_vec = vec![
             vec![DCRTPoly::const_zero(&params), DCRTPoly::const_zero(&params)],
-            vec![DCRTPoly::const_zero(&params), DCRTPoly::from_const(&params, &value)],
+            vec![DCRTPoly::const_zero(&params), DCRTPoly::from_elem_to_constant(&params, &value)],
         ];
 
         let matrix2 = DCRTPolyMatrix::from_poly_vec(&params, matrix2_vec);
@@ -561,7 +560,7 @@ mod tests {
 
         // Create first matrix with value at (0,0)
         let matrix1_vec = vec![
-            vec![DCRTPoly::from_const(&params, &value), DCRTPoly::const_zero(&params)],
+            vec![DCRTPoly::from_elem_to_constant(&params, &value), DCRTPoly::const_zero(&params)],
             vec![DCRTPoly::const_zero(&params), DCRTPoly::const_zero(&params)],
         ];
 
@@ -569,7 +568,7 @@ mod tests {
 
         // Create second matrix with value at (0,0)
         let matrix2_vec = vec![
-            vec![DCRTPoly::from_const(&params, &value), DCRTPoly::const_zero(&params)],
+            vec![DCRTPoly::from_elem_to_constant(&params, &value), DCRTPoly::const_zero(&params)],
             vec![DCRTPoly::const_zero(&params), DCRTPoly::const_zero(&params)],
         ];
 
@@ -594,8 +593,14 @@ mod tests {
         let value11 = FinRingElem::new(1990091289902891278121564387120912660u128, params.modulus());
 
         let matrix_vec = vec![
-            vec![DCRTPoly::from_const(&params, &value00), DCRTPoly::from_const(&params, &value01)],
-            vec![DCRTPoly::from_const(&params, &value10), DCRTPoly::from_const(&params, &value11)],
+            vec![
+                DCRTPoly::from_elem_to_constant(&params, &value00),
+                DCRTPoly::from_elem_to_constant(&params, &value01),
+            ],
+            vec![
+                DCRTPoly::from_elem_to_constant(&params, &value10),
+                DCRTPoly::from_elem_to_constant(&params, &value11),
+            ],
         ];
 
         let matrix = DCRTPolyMatrix::from_poly_vec(&params, matrix_vec);
@@ -612,12 +617,12 @@ mod tests {
 
         let expected_vec = vec![
             vec![
-                DCRTPoly::from_const(&params, &new_value00),
-                DCRTPoly::from_const(&params, &new_value01),
+                DCRTPoly::from_elem_to_constant(&params, &new_value00),
+                DCRTPoly::from_elem_to_constant(&params, &new_value01),
             ],
             vec![
-                DCRTPoly::from_const(&params, &new_value10),
-                DCRTPoly::from_const(&params, &new_value11),
+                DCRTPoly::from_elem_to_constant(&params, &new_value10),
+                DCRTPoly::from_elem_to_constant(&params, &new_value11),
             ],
         ];
 

--- a/src/poly/dcrt/poly.rs
+++ b/src/poly/dcrt/poly.rs
@@ -198,6 +198,7 @@ impl Poly for DCRTPoly {
     /// `int` is limited as u64 or u32.
     fn from_usize_to_lsb(params: &Self::Params, int: usize) -> Self {
         let n = params.ring_dimension() as usize;
+        debug_assert!(int < (1 << n), "Input exceeds representable range for ring dimension");
         let q = params.modulus();
         let one = FinRingElem::one(&q);
         let zero = FinRingElem::zero(&q);
@@ -362,7 +363,7 @@ impl Poly for DCRTPoly {
             if i >= usize::BITS as usize {
                 break;
             }
-            sum += (1usize << i) * (c as usize);
+            sum = sum.saturating_add((1usize << i).saturating_mul(c as usize));
         }
         sum
     }

--- a/src/poly/dcrt/poly.rs
+++ b/src/poly/dcrt/poly.rs
@@ -171,12 +171,19 @@ impl Poly for DCRTPoly {
         Self::from_coeffs(params, &coeffs)
     }
 
-    fn const_int(params: &Self::Params, int: usize) -> Self {
-        Self::poly_gen_from_const(params, BigUint::from(int).to_string())
+    /// from `BigUint` to `DCRTPoly` type and generate constant polynomial.
+    fn from_biguint_to_constant(params: &Self::Params, int: BigUint) -> Self {
+        Self::poly_gen_from_const(params, int.to_string())
+    }
+
+    /// from `usize` to `DCRTPoly` type and generate constant polynomial.
+    fn from_usize_to_constant(params: &Self::Params, int: usize) -> Self {
+        Self::poly_gen_from_const(params, int.to_string())
     }
 
     /// Encode `int` in little-endian bit order
-    fn from_const_int_lsb(params: &Self::Params, int: usize) -> Self {
+    /// `int` is limited as u64 or u32.
+    fn from_usize_to_lsb(params: &Self::Params, int: usize) -> Self {
         let n = params.ring_dimension() as usize;
         let q = params.modulus();
         let one = FinRingElem::one(&q);
@@ -463,8 +470,8 @@ mod tests {
 
         for _ in 0..10 {
             let value = rng.random_range(0..(2_i32.pow(params.ring_dimension() - 1) as usize));
-            let lsb_poly = DCRTPoly::from_const_int_lsb(&params, value);
-            let poly = DCRTPoly::const_int(&params, value);
+            let lsb_poly = DCRTPoly::from_usize_to_lsb(&params, value);
+            let poly = DCRTPoly::from_usize_to_constant(&params, value);
             let back = poly.to_const_int();
             let back_from_lsb = lsb_poly.to_const_int();
             assert_eq!(value, back);

--- a/src/poly/dcrt/poly.rs
+++ b/src/poly/dcrt/poly.rs
@@ -182,8 +182,15 @@ impl Poly for DCRTPoly {
         let one = FinRingElem::one(&q);
         let zero = FinRingElem::zero(&q);
 
-        let coeffs: Vec<FinRingElem> =
-            (0..n).map(|i| if (int >> i) & 1 == 1 { one.clone() } else { zero.clone() }).collect();
+        let coeffs: Vec<FinRingElem> = (0..n)
+            .map(|i| {
+                if i < usize::BITS as usize && (int >> i) & 1 == 1 {
+                    one.clone()
+                } else {
+                    zero.clone()
+                }
+            })
+            .collect();
 
         Self::from_coeffs(params, &coeffs)
     }
@@ -330,11 +337,14 @@ impl Poly for DCRTPoly {
     }
 
     fn to_const_int(&self) -> usize {
-        let mut sum = 0;
+        let mut sum = 0usize;
         for (i, c) in self.coeffs_digits().into_iter().enumerate() {
-            sum += 2_u32.pow(i as u32) * c;
+            if i >= usize::BITS as usize {
+                break;
+            }
+            sum += (1usize << i) * (c as usize);
         }
-        sum as usize
+        sum
     }
 
     fn from_bool_vec(params: &Self::Params, coeffs: &[bool]) -> Self {

--- a/src/poly/enc.rs
+++ b/src/poly/enc.rs
@@ -24,7 +24,8 @@ where
     let e = sampler_uniform.sample_uniform(params, 1, 1, DistType::GaussDist { sigma });
 
     // Use provided scale or calculate half of q
-    let scale = M::P::from_const(params, &<M::P as Poly>::Elem::half_q(&params.modulus()));
+    let scale =
+        M::P::from_elem_to_constant(params, &<M::P as Poly>::Elem::half_q(&params.modulus()));
 
     // Compute RLWE encryption: t * a + e + m * scale
     t.clone() * a + e + &(m.clone() * &scale)

--- a/src/poly/polynomial.rs
+++ b/src/poly/polynomial.rs
@@ -1,4 +1,5 @@
 use itertools::Itertools;
+use num_bigint::BigUint;
 use std::{
     fmt::Debug,
     hash::Hash,
@@ -82,8 +83,9 @@ pub trait Poly:
     fn const_one(params: &Self::Params) -> Self;
     fn const_minus_one(params: &Self::Params) -> Self;
     fn const_power_of_base(params: &Self::Params, k: usize) -> Self;
-    fn const_int(params: &Self::Params, int: usize) -> Self;
-    fn from_const_int_lsb(params: &Self::Params, int: usize) -> Self;
+    fn from_biguint_to_constant(params: &Self::Params, int: BigUint) -> Self;
+    fn from_usize_to_constant(params: &Self::Params, int: usize) -> Self;
+    fn from_usize_to_lsb(params: &Self::Params, int: usize) -> Self;
     fn const_rotate_poly(params: &Self::Params, shift: usize) -> Self {
         let zero = Self::const_zero(params);
         let mut coeffs = zero.coeffs();

--- a/src/poly/polynomial.rs
+++ b/src/poly/polynomial.rs
@@ -51,7 +51,6 @@ pub trait Poly:
     type Params: PolyParams<Modulus = <Self::Elem as PolyElem>::Modulus>;
     fn from_bool_vec(params: &Self::Params, coeffs: &[bool]) -> Self;
     fn from_coeffs(params: &Self::Params, coeffs: &[Self::Elem]) -> Self;
-    fn from_const(params: &Self::Params, constant: &Self::Elem) -> Self;
     fn from_decomposed(params: &Self::Params, decomposed: &[Self]) -> Self;
     fn from_bytes(params: &Self::Params, bytes: &[u8]) -> Self {
         let log_q_bytes = params.modulus_bits().div_ceil(8);
@@ -83,6 +82,7 @@ pub trait Poly:
     fn const_one(params: &Self::Params) -> Self;
     fn const_minus_one(params: &Self::Params) -> Self;
     fn const_power_of_base(params: &Self::Params, k: usize) -> Self;
+    fn from_elem_to_constant(params: &Self::Params, constant: &Self::Elem) -> Self;
     fn from_biguint_to_constant(params: &Self::Params, int: BigUint) -> Self;
     fn from_usize_to_constant(params: &Self::Params, int: usize) -> Self;
     fn from_usize_to_lsb(params: &Self::Params, int: usize) -> Self;

--- a/src/poly/polynomial.rs
+++ b/src/poly/polynomial.rs
@@ -81,7 +81,7 @@ pub trait Poly:
     fn const_zero(params: &Self::Params) -> Self;
     fn const_one(params: &Self::Params) -> Self;
     fn const_minus_one(params: &Self::Params) -> Self;
-    fn const_power_of_base(params: &Self::Params, k: usize) -> Self;
+    fn from_power_of_base_to_constant(params: &Self::Params, k: usize) -> Self;
     fn from_elem_to_constant(params: &Self::Params, constant: &Self::Elem) -> Self;
     fn from_biguint_to_constant(params: &Self::Params, int: BigUint) -> Self;
     fn from_usize_to_constant(params: &Self::Params, int: usize) -> Self;

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -4,10 +4,10 @@ use crate::{
     poly::{
         dcrt::{
             DCRTPoly, DCRTPolyHashSampler, DCRTPolyMatrix, DCRTPolyParams, DCRTPolyTrapdoorSampler,
-            DCRTPolyUniformSampler, FinRingElem,
+            DCRTPolyUniformSampler,
         },
         sampler::{DistType, PolyUniformSampler},
-        Poly, PolyElem, PolyParams,
+        Poly, PolyParams,
     },
     utils::{calculate_directory_size, init_tracing, log_mem},
 };
@@ -105,9 +105,7 @@ pub async fn test_io_common(
     let eval_time = start_time.elapsed();
     info!("Time for evaluation: {:?}", eval_time);
     info!("Total time: {:?}", obfuscation_time + eval_time);
-
-    let input_poly =
-        DCRTPoly::from_const(&params, &FinRingElem::constant(&params.modulus(), bool_in as u64));
+    let input_poly = DCRTPoly::from_usize_to_constant(&params, bool_in as usize);
     assert_eq!(output, (hardcoded_key * input_poly).to_bool_vec());
 }
 

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -210,8 +210,8 @@ fn setup_lsb_constant_binary_plt(t_n: usize, params: &DCRTPolyParams) -> PublicL
     for k in 0..t_n {
         let r_val: usize = rng.random_range(0..2 as usize);
         f.insert(
-            DCRTPoly::from_const_int_lsb(&params, k),
-            (k, DCRTPoly::const_int(&params, r_val)),
+            DCRTPoly::from_usize_to_lsb(&params, k),
+            (k, DCRTPoly::from_usize_to_constant(&params, r_val)),
         );
     }
 
@@ -224,8 +224,8 @@ pub fn setup_lsb_plt(t_n: usize, params: &DCRTPolyParams) -> PublicLut<DCRTPoly>
     for k in 0..t_n {
         let r_val: usize = t_n - k;
         f.insert(
-            DCRTPoly::from_const_int_lsb(&params, k),
-            (k, DCRTPoly::from_const_int_lsb(&params, r_val)),
+            DCRTPoly::from_usize_to_lsb(&params, k),
+            (k, DCRTPoly::from_usize_to_lsb(&params, r_val)),
         );
     }
 
@@ -238,7 +238,10 @@ pub fn setup_constant_plt(t_n: usize, params: &DCRTPolyParams) -> PublicLut<DCRT
     let mut rng = rng();
     for k in 0..t_n {
         let r_val: usize = rng.random_range(0..t_n as usize);
-        f.insert(DCRTPoly::const_int(&params, k), (k, DCRTPoly::const_int(&params, r_val)));
+        f.insert(
+            DCRTPoly::from_usize_to_constant(&params, k),
+            (k, DCRTPoly::from_usize_to_constant(&params, r_val)),
+        );
     }
 
     let plt = PublicLut::<DCRTPoly>::new(f);


### PR DESCRIPTION
This is a real fix for PLT where the assertion is not working
: the issue was on `from_usize_to_lsb` method was previously overflowed at u64, so in real parameter case as the polynomial demension is over 64 bit, this lsb bit representation had repeated instead on filling up in 0. This is different behavior on our plaintext polynomial which is fully constant polynomial(only first few bytes are filled rest is 0). 

Also added some refactorings on methods as it was unclear what format of polynomial it returns via method name.

fixed benchmark: https://github.com/MachinaIO/diamond-io/actions/runs/16595490483/job/46941038176
